### PR TITLE
Handle Fahrenheit when logging currentTemp

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ function updateValues(that) {
         if (!(accessory.log_event_counter % 10)) {
           accessory.loggingService.addEntry({
             time: moment().unix(),
-            currentTemp: roundInt(deviceData.latestData.uiData.DispTemperature),
+            currentTemp: roundInt(tcc.toHBTemperature(deviceData, deviceData.latestData.uiData.DispTemperature)),
             setTemp: roundInt(tcc.toHBTargetTemperature(deviceData)),
             valvePosition: roundInt(deviceData.latestData.uiData.EquipmentOutputStatus)
           });


### PR DESCRIPTION
I found that my temperature was being incorrectly logged as Fahrenheit instead of being converted to Celsius.