### PR TITLE
Update tcc to support using permanent holds

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ implementation into HomeKit. This plugin is work in progress. Help is appreciate
             "username" : ".....",
             "password" : ".....",
             "devices" : [
-                  {"deviceID": "1234567","name": "Other Floor"},
-                  {"deviceID": "abcdefg","name": "Main Floor"}
+                  {"deviceID": "1234567", "name": "Other Floor", "usePermanentHolds": true},
+                  {"deviceID": "abcdefg", "name": "Main Floor", "usePermanentHolds": false}
           	]
         },
     ]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The last part is your Device ID.
 
 * `refresh` - Data polling interval in seconds, defaults to 60 seconds
 * `storage` - Storage of chart graphing data for history graphing, either fs or googleDrive, defaults to fs
+* `usePermanentHolds` - Place in the `device` block correlated with your thermostat. If set to `true`, temperature changes will be set as permanent holds, rather than temporary holds. This will allow you to use HomeKit automations to completely replace your thermostat's schedule. If set to `false`, the temperature changes will expire after a certain period of time and resume your normal schedule. By default, this is off.
 
 # Roadmap
 
@@ -71,3 +72,4 @@ It seems to be vitally important to set the right system time, especially on ras
 - gsulshski - Validation of TH6320WF
 - l3nticular - Support for Mode 7
 - simont77 - FakeGato History
+- @hakusaro - Added support for permanent temperature holds.

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ tccPlatform.prototype = {
               } else {
 
                 var newAccessory = new tccAccessory(that.log, device.name,
-                  deviceData, that.username, that.password, device.deviceID);
+                  deviceData, that.username, that.password, device.deviceID, device.usePermanentHolds);
                 // store accessory in myAccessories
                 myAccessories.push(newAccessory);
                 resolve();
@@ -189,7 +189,7 @@ function updateValues(that) {
 
 // give this function all the parameters needed
 
-function tccAccessory(log, name, deviceData, username, password, deviceID) {
+function tccAccessory(log, name, deviceData, username, password, deviceID, usePermanentHolds) {
 
   var uuid = UUIDGen.generate(name);
 
@@ -203,6 +203,7 @@ function tccAccessory(log, name, deviceData, username, password, deviceID) {
   this.username = username;
   this.password = password;
   this.deviceID = deviceID;
+  this.usePermanentHolds = usePermanentHolds;
   this.log_event_counter = 9;   // Update fakegato on startup
 }
 
@@ -280,7 +281,7 @@ tccAccessory.prototype = {
           break;
       }
       that.log("setHeatCoolSetpoint", that.name, that.device.latestData.uiData.StatusHeat, that.device.latestData.uiData.StatusCool);
-      session.setHeatCoolSetpoint(that.deviceID, heatSetPoint, coolSetPoint).then(function(taskId) {
+      session.setHeatCoolSetpoint(that.deviceID, heatSetPoint, coolSetPoint, that.usePermanentHolds).then(function(taskId) {
         that.log("Successfully changed temperature!", that.name, taskId);
         if (taskId.success) {
           that.log("Successfully changed temperature!", taskId);
@@ -320,7 +321,7 @@ tccAccessory.prototype = {
       // verify that the task did succeed
 
       tcc.login(this.username, this.password).then(function(session) {
-        session.setHeatCoolSetpoint(that.deviceID, null, value).then(function(taskId) {
+        session.setHeatCoolSetpoint(that.deviceID, null, value, that.usePermanentHolds).then(function(taskId) {
           that.log("Successfully changed cooling threshold!");
           that.log(taskId);
           // returns taskId if successful

--- a/lib/tcc.js
+++ b/lib/tcc.js
@@ -45,9 +45,15 @@ Session.prototype.CheckDataSession = function(deviceID, cb) {
 // {"DeviceID":1234567,"SystemSwitch":null,"HeatSetpoint":20,"CoolSetpoint":null,"HeatNextPeriod":null,"CoolNextPeriod"
 // :null,"StatusHeat":null,"StatusCool":null,"FanMode":null}
 
-Session.prototype.setHeatCoolSetpoint = function(deviceId, heatSetPoint, coolSetPoint) {
+Session.prototype.setHeatCoolSetpoint = function(deviceId, heatSetPoint, coolSetPoint, usePermanentHolds) {
   var deferred = Q.defer();
   var url = "https://mytotalconnectcomfort.com/portal/Device/SubmitControlScreenChanges";
+
+  // Next status is 1 for temporary or 2 for permanent hold.
+  var nextStatus = 1;
+  if (usePermanentHolds) {
+    nextStatus = 2;
+  }
 
   var body = JSON.stringify({
     "DeviceID": Number(deviceId),
@@ -56,8 +62,8 @@ Session.prototype.setHeatCoolSetpoint = function(deviceId, heatSetPoint, coolSet
     "CoolSetpoint": coolSetPoint,
     "HeatNextPeriod": null,
     "CoolNextPeriod": null,
-    "StatusHeat": 1,
-    "StatusCool": 1,
+    "StatusHeat": nextStatus,
+    "StatusCool": nextStatus,
     "FanMode": null
   });
 


### PR DESCRIPTION
This adds a config option on a per device level to support sending
permanent hold commands instead of temporary hold commands. In effect,
by setting this config option, an end user can configure 100% of their
schedule using HomeKit, as opposed to using any of the thermostat's
native stuff.

Fixes #43.