### PR TITLE
Fix login failure when username or password contain special characters

### DIFF
--- a/lib/tcc.js
+++ b/lib/tcc.js
@@ -154,7 +154,7 @@ tcc.prototype._login = function() {
     (async () => {
       try {
         HEADER.soapAction = 'http://services.alarmnet.com/Services/MobileV2/AuthenticateUserLogin';
-        var message = '<?xml version="1.0" encoding="utf-8"?>' + parser.toXml(tccMessage.soapMessage(tccMessage.AuthenticateUserLoginMessage(this._username, this._password)));
+        var message = '<?xml version="1.0" encoding="utf-8"?>' + parser.toXml(tccMessage.soapMessage(tccMessage.AuthenticateUserLoginMessage(this._username, this._password)), { sanitize: true });
         var {
           response
         } = await soapRequest({


### PR DESCRIPTION
Prevents `SOAP FAIL: Error: Request failed with status code 400` errors when trying to login with a username or password that contain special XML characters https://docs.oracle.com/cd/A97335_02/apps.102/bc4j/developing_bc_projects/obcCustomXml.htm.

Thanks for creating this plugin!