### PR TITLE
Add temp humidity sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,22 @@ To resolve the issue, please follow the steps here. https://github.com/nodejs/no
 * `refresh` - Data polling interval in seconds, defaults to 60 seconds
 * `storage` - Storage of chart graphing data for history graphing, either fs or googleDrive, defaults to fs
 * `usePermanentHolds` - If set to `true`, temperature changes will be set as permanent holds, rather than temporary holds. This will allow you to use HomeKit automations to completely replace your thermostat's schedule. If set to `false`, the temperature changes will expire after a certain period of time and resume your normal schedule. By default, this is off.
+* `sensors` - Enables temperature/humidity HomeKit sensors (useful for automations), options include: 
+  * `none` - No sensors will be shown (this is default setting)
+  * `all` - Enables all available temperature/humidity sensors
+  * `inside` - Enables temperature and humidity sensors for each thermostat
+  * `outside` - Enables a single set of outdoor temperature and humidity sensors
+  * `advanced` -  Allows for granular control of which temperature/humidity sensors to show, requires `devices` option (see below)
 * `debug` - Enables debug level logging from the plugin, defaults to `false`, to enable set to `true`
-* `devices` and `deviceID` - required to setup temperature/humidity sensors, `deviceID` is obtained by looking at your Homebridge logs for TCC entries when you restart (alternatively, if you login to Honeywell's site, you can see the id when using links for each thermostat)
-* `insideTemperature` - Enables separate temperature sensor in HomeKit (useful for automations), to enable set to `true` on each thermostat
-* `outsideTemperature` - Enables separate temperature sensor in HomeKit (useful for automations), to enable set to `true` on each thermostat
-* `insideHumidity` - Enables separate humidity sensor in HomeKit (useful for automations), to enable set to `true` on each thermostat
-* `outsideHumidity` - Enables separate humidity sensor in HomeKit (useful for automations), to enable set to `true` on each thermostat
+  
+# Advanced settings
+
+* Use with `"sensors": "advanced"` option above, allows for granular control over which sensors are shown by individual thermostat
+* `devices` and `deviceID` - See example below for config directives, `deviceID` is obtained by looking at your Homebridge logs for TCC entries when you restart (alternatively, if you login to Honeywell's site, you can see the id when using links for each thermostat)
+* `insideTemperature` - Enables thermostat temperature sensor in HomeKit, to enable set to `true` on each thermostat
+* `outsideTemperature` - Enables outdoor temperature sensor in HomeKit, to enable set to `true` on each thermostat
+* `insideHumidity` - Enables thermostat humidity sensor in HomeKit, to enable set to `true` on each thermostat
+* `outsideHumidity` - Enables outdoor humidity sensor in HomeKit, to enable set to `true` on each thermostat
 
 ```
 "platforms": [
@@ -70,12 +80,20 @@ To resolve the issue, please follow the steps here. https://github.com/nodejs/no
             "name" : "Thermostat",
             "username" : ".....",
             "password" : ".....",
+            "sensors" : "advanced",
             "devices": [{
                 "deviceID": "3910306",
                 "insideTemperature": true,
                 "insideHumidity": true,
                 "outsideTemperature": true,
                 "outsideHumidity": true
+            },
+            {
+                "deviceID": "3910307",
+                "insideTemperature": true,
+                "insideHumidity": true,
+                "outsideTemperature": false,
+                "outsideHumidity": false
             }]
         }
     ]
@@ -93,3 +111,4 @@ To resolve the issue, please follow the steps here. https://github.com/nodejs/no
 - simont77 - FakeGato History
 - hakusaro - Added support for permanent temperature holds.
 - jcgorla-dev - Validation of Honeywell's Prestige IAQ Thermostat
+- kylerove - Added support for separate temperature / humidity sensors

--- a/README.md
+++ b/README.md
@@ -61,43 +61,7 @@ To resolve the issue, please follow the steps here. https://github.com/nodejs/no
   * `all` - Enables all available temperature/humidity sensors
   * `inside` - Enables temperature and humidity sensors for each thermostat
   * `outside` - Enables a single set of outdoor temperature and humidity sensors
-  * `advanced` -  Allows for granular control of which temperature/humidity sensors to show, requires `devices` option (see below)
 * `debug` - Enables debug level logging from the plugin, defaults to `false`, to enable set to `true`
-  
-# Advanced settings
-
-* Use with `"sensors": "advanced"` option above, allows for granular control over which sensors are shown by individual thermostat
-* `devices` and `deviceID` - See example below for config directives, `deviceID` is obtained by looking at your Homebridge logs for TCC entries when you restart (alternatively, if you login to Honeywell's site, you can see the id when using links for each thermostat)
-* `insideTemperature` - Enables thermostat temperature sensor in HomeKit, to enable set to `true` on each thermostat
-* `outsideTemperature` - Enables outdoor temperature sensor in HomeKit, to enable set to `true` on each thermostat
-* `insideHumidity` - Enables thermostat humidity sensor in HomeKit, to enable set to `true` on each thermostat
-* `outsideHumidity` - Enables outdoor humidity sensor in HomeKit, to enable set to `true` on each thermostat
-
-```
-"platforms": [
-       {
-            "platform": "tcc",
-            "name" : "Thermostat",
-            "username" : ".....",
-            "password" : ".....",
-            "sensors" : "advanced",
-            "devices": [{
-                "deviceID": "3910306",
-                "insideTemperature": true,
-                "insideHumidity": true,
-                "outsideTemperature": true,
-                "outsideHumidity": true
-            },
-            {
-                "deviceID": "3910307",
-                "insideTemperature": true,
-                "insideHumidity": true,
-                "outsideTemperature": false,
-                "outsideHumidity": false
-            }]
-        }
-    ]
-```
 
 # Credits
 
@@ -111,4 +75,4 @@ To resolve the issue, please follow the steps here. https://github.com/nodejs/no
 - simont77 - FakeGato History
 - hakusaro - Added support for permanent temperature holds.
 - jcgorla-dev - Validation of Honeywell's Prestige IAQ Thermostat
-- kylerove - Added support for separate temperature / humidity sensors
+- kylerove - Added support for separate indoor and outdoor temperature / humidity sensors

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Plugin will discover your thermostats and create one for each connected to your 
 
 ## On Windows platforms
 
-Please ensure the node-gyp is properly configured for use prior to installing.  Error messages like this may appear during installtion if not.
+Please ensure the node-gyp is properly configured for use prior to installing.  Error messages like this may appear during installation if not.
 
 ```
 gyp ERR! find Python Python is not set from command line or npm configuration
@@ -57,7 +57,7 @@ To resolve the issue, please follow the steps here. https://github.com/nodejs/no
 * `storage` - Storage of chart graphing data for history graphing, either fs or googleDrive, defaults to fs
 * `usePermanentHolds` - If set to `true`, temperature changes will be set as permanent holds, rather than temporary holds. This will allow you to use HomeKit automations to completely replace your thermostat's schedule. If set to `false`, the temperature changes will expire after a certain period of time and resume your normal schedule. By default, this is off.
 * `debug` - Enables debug level logging from the plugin, defaults to `false`, to enable set to `true`
-* `devices` and `deviceID` - required to setup temperature/humidity sensors, id is obtained by looking at your homebridge logs for TCC entries when you restart
+* `devices` and `deviceID` - required to setup temperature/humidity sensors, `deviceID` is obtained by looking at your Homebridge logs for TCC entries when you restart (alternatively, if you login to Honeywell's site, you can see the id when using links for each thermostat)
 * `insideTemperature` - Enables separate temperature sensor in HomeKit (useful for automations), to enable set to `true` on each thermostat
 * `outsideTemperature` - Enables separate temperature sensor in HomeKit (useful for automations), to enable set to `true` on each thermostat
 * `insideHumidity` - Enables separate humidity sensor in HomeKit (useful for automations), to enable set to `true` on each thermostat

--- a/README.md
+++ b/README.md
@@ -57,10 +57,29 @@ To resolve the issue, please follow the steps here. https://github.com/nodejs/no
 * `storage` - Storage of chart graphing data for history graphing, either fs or googleDrive, defaults to fs
 * `usePermanentHolds` - If set to `true`, temperature changes will be set as permanent holds, rather than temporary holds. This will allow you to use HomeKit automations to completely replace your thermostat's schedule. If set to `false`, the temperature changes will expire after a certain period of time and resume your normal schedule. By default, this is off.
 * `debug` - Enables debug level logging from the plugin, defaults to `false`, to enable set to `true`
+* `devices` and `deviceID` - required to setup temperature/humidity sensors, id is obtained by looking at your homebridge logs for TCC entries when you restart
 * `insideTemperature` - Enables separate temperature sensor in HomeKit (useful for automations), to enable set to `true` on each thermostat
 * `outsideTemperature` - Enables separate temperature sensor in HomeKit (useful for automations), to enable set to `true` on each thermostat
 * `insideHumidity` - Enables separate humidity sensor in HomeKit (useful for automations), to enable set to `true` on each thermostat
 * `outsideHumidity` - Enables separate humidity sensor in HomeKit (useful for automations), to enable set to `true` on each thermostat
+
+```
+"platforms": [
+       {
+            "platform": "tcc",
+            "name" : "Thermostat",
+            "username" : ".....",
+            "password" : ".....",
+            "devices": [{
+                "deviceID": "3910306",
+                "insideTemperature": true,
+                "insideHumidity": true,
+                "outsideTemperature": true,
+                "outsideHumidity": true
+            }]
+        }
+    ]
+```
 
 # Credits
 

--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ function TccAccessory(that, device, config) {
   this.usePermanentHolds = that.usePermanentHolds;
   this.storage = that.storage;
   this.refresh = that.refresh;
-  debug("TccAccessory()" + config);
+  debug("TccAccessory()",config);
   
   var uuid = UUIDGen.generate(this.name + " - TCC");
 

--- a/index.js
+++ b/index.js
@@ -209,7 +209,7 @@ function updateStatus(accessory, device) {
 
 function TccAccessory(that, device, sensors) {
   this.log = that.log;
-  this.log("Adding TCC Device", device.DeviceName);
+  this.log("Adding TCC Device", device.Name);
   this.name = device.Name;
   this.ThermostatID = device.ThermostatID;
   this.device = device;
@@ -364,7 +364,7 @@ function TccAccessory(that, device, sensors) {
 
 function TccSensorsAccessory(that, device, sensors) {
   this.log = that.log;
-  this.log("Adding TCC Device", device.DeviceName);
+  this.log("Adding TCC Sensors Device");
   this.name = "Outside Sensors"
   this.ThermostatID = device.ThermostatID;
   this.device = device;

--- a/index.js
+++ b/index.js
@@ -254,7 +254,10 @@ function TccAccessory(that, device, sensors, advanced) {
       }
       break;
   }
-
+  debug ("createInsideSensors: ",createInsideSensors);
+  debug ("createOutsideSensors: ", createOutsideSensors);
+  debug ("thisDeviceConfig: ", thisDeviceConfig);
+  
   if (!getAccessoryByThermostatID(this.ThermostatID)) {
     this.log("Adding TCC Device (deviceID="+this.ThermostatID+")", this.name);
     this.accessory = new Accessory(this.name, uuid, 10);

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ tccPlatform.prototype.configureAccessory = function(accessory) {
 
 function pollDevices() {
   thermostats.pollThermostat().then((devices) => {
-    this.log("pollDevices():", this.config);
+    this.log("pollDevices():", this.devices);
     myAccessories.forEach(function(accessory) {
       debug("pollDevices - updateStatus", accessory.displayName);
       if (devices.hb[accessory.context.ThermostatID]) {

--- a/index.js
+++ b/index.js
@@ -244,9 +244,12 @@ function TccAccessory(that, device, sensors, advanced) {
       // default no sensors and look to thisDeviceConfig directives for logic on which sensors to instantiate
       createInsideSensors = false;
       createOutsideSensors = false;
-      for (let i = 0; i < advanced.length; i++) {
-        if (advanced[i].deviceID == this.ThermostatID) {
-          var thisDeviceConfig = advanced[i];
+      var thisDeviceConfig = [{"insideTemperature":false,"insideHumidity":false,"outsideTemperature":false,"outsideHumidity":false}];
+      if (advanced.length > 0) {
+        for (let i = 0; i < advanced.length; i++) {
+          if (advanced[i].deviceID == this.ThermostatID) {
+            var thisDeviceConfig = advanced[i];
+          }
         }
       }
       break;
@@ -268,7 +271,7 @@ function TccAccessory(that, device, sensors, advanced) {
     this.accessory.addService(Service.Thermostat, this.name);
     
     // check if user wants separate temperature and humidity sensors by zone/thermostat
-    if (createInsideSensors || (thisDeviceConfig.insideTemperature || false)) {
+    if (createInsideSensors || thisDeviceConfig.insideTemperature) {
       debug("TccAccessory() " + this.name + " InsideTemperature = true, existing sensor");
       this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "INSIDE");
       
@@ -279,7 +282,7 @@ function TccAccessory(that, device, sensors, advanced) {
           maxValue: 100
         });
     }
-    if (createOutsideSensors || (thisDeviceConfig.outsideTemperature || false)) {
+    if (createOutsideSensors || thisDeviceConfig.outsideTemperature) {
       debug("TccAccessory() " + this.name + " outsideTemperature = true, existing sensor");
       this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "OUTSIDE");
       
@@ -290,14 +293,14 @@ function TccAccessory(that, device, sensors, advanced) {
           maxValue: 100
         });
     }
-    if (createInsideSensors || (thisDeviceConfig.insideHumidity || false)) {
+    if (createInsideSensors || thisDeviceConfig.insideHumidity) {
       debug("TccAccessory() " + this.name + " insideHumidity = true, existing sensor");
       this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "INSIDE");
       
       this.InsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);
     }
-    if (createOutsideSensors || (thisDeviceConfig.outsideHumidity || false)) {
+    if (createOutsideSensors || thisDeviceConfig.outsideHumidity) {
       debug("TccAccessory() " + this.name + " outsideHumidity = true, existing sensor");
       this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "OUTSIDE");
       
@@ -375,7 +378,7 @@ function TccAccessory(that, device, sensors, advanced) {
     
     // need to check if accessory/zone/thermostat already exists, but user added temp/humidity sensors then must declare
     this.accessory = getAccessoryByThermostatID(this.ThermostatID);
-    if ((createInsideSensors || (thisDeviceConfig.insideTemperature || false))  && !this.accessory.getService(this.name + " Temperature")) {
+    if ((createInsideSensors || thisDeviceConfig.insideTemperature)  && !this.accessory.getService(this.name + " Temperature")) {
       debug("TccAccessory() " + this.name + " InsideTemperature = true, adding sensor");
       this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "Inside");
       
@@ -386,7 +389,7 @@ function TccAccessory(that, device, sensors, advanced) {
           maxValue: 100
         });
     }
-    if ((createOutsideSensors || (thisDeviceConfig.outsideTemperature || false))  && !this.accessory.getService("Outside Temperature")) {
+    if ((createOutsideSensors || thisDeviceConfig.outsideTemperature)  && !this.accessory.getService("Outside Temperature")) {
       debug("TccAccessory() " + this.name + " OutsideTemperature = true, adding sensor");
       this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "Outside");
       
@@ -397,14 +400,14 @@ function TccAccessory(that, device, sensors, advanced) {
           maxValue: 100
         });
     }
-    if ((createInsideSensors || (thisDeviceConfig.insideHumidity || false))  && !this.accessory.getService(this.name + " Humidity")) {
+    if ((createInsideSensors || thisDeviceConfig.insideHumidity)  && !this.accessory.getService(this.name + " Humidity")) {
       debug("TccAccessory() " + this.name + " InsideHumidity = true, adding sensor");
       this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "Inside");
       
       this.InsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);
     }
-    if ((createOutsideSensors || (thisDeviceConfig.outsideHumidity || false)) && !this.accessory.getService("Outside Humidity")) {
+    if ((createOutsideSensors || thisDeviceConfig.outsideHumidity) && !this.accessory.getService("Outside Humidity")) {
       debug("TccAccessory() " + this.name + " outsideHumidity = true, adding sensor");
       this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "Outside");
       

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ tccPlatform.prototype.didFinishLaunching = function() {
 
 tccPlatform.prototype.configureAccessory = function(accessory) {
   this.log("configureAccessory %s", accessory.displayName);
-
+  debug(accessory.context)
   if (accessory.getService(Service.Thermostat)) {
     accessory.log = this.log;
     accessory

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ tccPlatform.prototype.didFinishLaunching = function() {
       debug("Creating accessory for", devices.hb[zone].Name);
       debug("Creating accessory for", devices.hb[zone].ThermostatID);
       debug("tccPlatform.prototype.didFinishLaunching()",this.devices)
-      var newAccessory = new TccAccessory(this, devices.hb[zone]);
+      var newAccessory = new TccAccessory(this, devices.hb[zone], this.devices);
       updateStatus(newAccessory, devices.hb[zone], this.devices);
     }
   }).catch((err) => {
@@ -201,7 +201,7 @@ function updateStatus(accessory, device, config) {
   }
 }
 
-function TccAccessory(that, device) {
+function TccAccessory(that, device, config) {
   this.log = that.log;
   // this.log("Adding TCC Device", device.DeviceName);
   this.name = device.Name;
@@ -210,15 +210,13 @@ function TccAccessory(that, device) {
   this.usePermanentHolds = that.usePermanentHolds;
   this.storage = that.storage;
   this.refresh = that.refresh;
-  this.devices = that.devices;
-  debug("TccAccessory()" + that.usePermanentHolds);
-  debug("TccAccessory()" + that.devices);
+  debug("TccAccessory()" + config);
   
   var uuid = UUIDGen.generate(this.name + " - TCC");
 
   // need to get config for this thermostat id
   for (let i = 0; i < config.length; i++) {
-    if (deviceConfig[i].deviceID == accessory.context.ThermostatID) {
+    if (deviceConfig[i].deviceID == this.ThermostatID) {
       var thisDeviceConfig = deviceConfig[i];
     }
   }
@@ -239,7 +237,7 @@ function TccAccessory(that, device) {
     this.accessory.addService(Service.Thermostat, this.name);
     
     // check if user wants separate temperature and humidity sensors by zone/thermostat
-    if (this.deviceConfig.insideTemperature || false) {
+    if (thisDeviceConfig.insideTemperature || false) {
       this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + "Temperature", "INSIDE");
       
       this.InsideTemperatureService
@@ -249,7 +247,7 @@ function TccAccessory(that, device) {
           maxValue: 100
         });
     }
-    if (this.deviceConfig.outsideTemperature || false) {
+    if (thisDeviceConfig.outsideTemperature || false) {
       this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "OUTSIDE");
       
       this.OutsideTemperatureService
@@ -259,13 +257,13 @@ function TccAccessory(that, device) {
           maxValue: 100
         });
     }
-    if (this.deviceConfig.insideHumidity || false) {
+    if (thisDeviceConfig.insideHumidity || false) {
       this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + "Humidity", "INSIDE");
       
       this.InsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);
     }
-    if (this.deviceConfig.outsideHumidity || false) {
+    if (thisDeviceConfig.outsideHumidity || false) {
       this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "OUTSIDE");
       
       this.OutsideHumidityService

--- a/index.js
+++ b/index.js
@@ -52,8 +52,7 @@ tccPlatform.prototype.didFinishLaunching = function() {
   thermostats = new Tcc(this);
   thermostats.pollThermostat().then((devices) => {
     for (var zone in devices.hb) {
-      debug("Creating accessory for", devices.hb[zone].Name);
-      debug("Creating accessory for", devices.hb[zone].ThermostatID);
+      debug("Creating accessory for", devices.hb[zone].Name + "(" + devices.hb[zone].ThermostatID + ")");
       //debug("tccPlatform.prototype.didFinishLaunching()",this.devices)
       var newAccessory = new TccAccessory(this, devices.hb[zone], this.sensors);
       updateStatus(newAccessory, devices.hb[zone]);
@@ -237,7 +236,7 @@ function TccAccessory(that, device, sensors) {
   }
   debug ("createInsideSensors: ",createInsideSensors);
   
-  if (!getAccessoryByThermostatID(this.ThermostatID)) {
+  if (!getAccessoryByName(this.name)) {
     this.log("Adding TCC Device (deviceID="+this.ThermostatID+")", this.name);
     this.accessory = new Accessory(this.name, uuid, 10);
     this.accessory.log = that.log;
@@ -369,7 +368,7 @@ function TccSensorsAccessory(that, device, sensors) {
   this.device = device;
   this.storage = that.storage;
   this.refresh = that.refresh;
-  //debug("TccSensorsAccessory()",config);
+  debug("TccSensorsAccessory()",device);
   
   var uuid = UUIDGen.generate(this.name + " - TCC");
   

--- a/index.js
+++ b/index.js
@@ -106,13 +106,8 @@ function pollDevices() {
     myAccessories.forEach(function(accessory) {
       debug("pollDevices - updateStatus", accessory.displayName);
       if (devices.hb[accessory.context.ThermostatID]) {
-        // push config settings for this thermostat along with next function
-        for (var deviceConfig in this.devices) {
-          if (deviceConfig.deviceID == accessory.context.ThermostatID) {
-            this.deviceConfig = deviceConfig;
-          }
-        }
-        updateStatus(accessory, devices.hb[accessory.context.ThermostatID], this.deviceConfig);
+        this.log("pollDevices()", this.devices);
+        updateStatus(accessory, devices.hb[accessory.context.ThermostatID]).bind(this);
       } else {
         this.log("ERROR: no data for", accessory.displayName);
         // debug("accessory", accessory);
@@ -137,7 +132,7 @@ function pollDevices() {
   });
 }
 
-function updateStatus(accessory, device, config) {
+function updateStatus(accessory, device) {
   accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.Name)
     .updateValue(device.Name);
   accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.Model)
@@ -145,23 +140,31 @@ function updateStatus(accessory, device, config) {
     
   var service = accessory.getService(Service.Thermostat);
 
+  // push config settings for this thermostat along with next function
+  this.log("updateStatus()", this.devices);
+  for (var deviceConfig in this.devices) {
+    if (deviceConfig.deviceID == accessory.context.ThermostatID) {
+      this.deviceConfig = deviceConfig;
+    }
+  }
+
   // check if user wants separate temperature and humidity sensors
-  if (config.insideTemperature || false) {
+  if (this.deviceConfig.insideTemperature || false) {
     var InsideTemperature = accessory.getService(device.Name + "Temperature");
     InsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.CurrentTemperature);
   }
-  if (config.outsideTemperature || false) {
+  if (this.deviceConfig.outsideTemperature || false) {
     var OutsideTemperature = accessory.getService("Outside Temperature");
     OutsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.OutsideTemperature);
   }
-  if (config.insideHumidity || false) {
+  if (this.deviceConfig.insideHumidity || false) {
     var InsideHumidity = accessory.getService(device.Name + "Humidity");
     InsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)
       .updateValue(device.InsideHumidity);
   }
-  if (config.outsideHumidity || false) {
+  if (this.deviceConfig.outsideHumidity || false) {
     var OutsideHumidity = accessory.getService("Outside Humidity");
 
     OutsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)

--- a/index.js
+++ b/index.js
@@ -110,6 +110,8 @@ tccPlatform.prototype.configureAccessory = function(accessory) {
   }
   
   // add fakegato logging for 
+  debug(accessory.getService("Outside Humidity"));
+  debug(accessory.getService("Outside Temperature"));
   if (accessory.getService("Outside Humidity") | accessory.getService("Outside Temperature")) {
     debug("FakeGatoHistoryService", this.storage, this.refresh);
     accessory.context.logEventCounter = 9; // Update fakegato on startup

--- a/index.js
+++ b/index.js
@@ -111,6 +111,7 @@ tccPlatform.prototype.configureAccessory = function(accessory) {
   
   // add fakegato logging for 
   if (accessory.displayName == "Outside Sensors") {
+    debug(accessory);
     debug("FakeGatoHistoryService", this.storage, this.refresh);
     accessory.context.logEventCounter = 9; // Update fakegato on startup
     accessory.loggingService = new FakeGatoHistoryService("weather", accessory, {
@@ -192,36 +193,12 @@ function updateStatus(accessory, device) {
   }
   
   // fakegato for outside sensor
-  if (accessory.getService("Outside Humidity") & accessory.getService("Outside Temperature")) {
+  if (accessory.displayName == "Outside Sensors") {
     accessory.context.logEventCounter++;
     if (!(accessory.context.logEventCounter % 10)) {
       accessory.loggingService.addEntry({
         time: moment().unix(),
         humidity: device.OutsideHumidity,
-        temp: device.OutsideTemperature,
-        pressure: 0
-      });
-      accessory.context.logEventCounter = 0;
-    }
-  }
-  else if (accessory.getService("Outside Humidity")) {
-    accessory.context.logEventCounter++;
-    if (!(accessory.context.logEventCounter % 10)) {
-      accessory.loggingService.addEntry({
-        time: moment().unix(),
-        humidity: device.OutsideHumidity,
-        temp: 0,
-        pressure: 0
-      });
-      accessory.context.logEventCounter = 0;
-    }
-  }
-  else if (accessory.getService("Outside Temperature")) {
-    accessory.context.logEventCounter++;
-    if (!(accessory.context.logEventCounter % 10)) {
-      accessory.loggingService.addEntry({
-        time: moment().unix(),
-        humidity: 0,
         temp: device.OutsideTemperature,
         pressure: 0
       });

--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ function TccAccessory(that, device, sensors, advanced) {
         outsideSensors = 1;
       }
       break;
-    case: "advanced":
+    case "advanced":
       // default no sensors and look to thisDeviceConfig directives for logic on which sensors to instantiate
       createInsideSensors = false;
       createOutsideSensors = false;

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ tccPlatform.prototype.didFinishLaunching = function() {
 
 tccPlatform.prototype.configureAccessory = function(accessory) {
   this.log("configureAccessory %s", accessory.displayName);
-  debug(accessory.context)
+
   if (accessory.getService(Service.Thermostat)) {
     accessory.log = this.log;
     accessory
@@ -160,16 +160,6 @@ function updateStatus(accessory, device) {
     var InsideTemperature = accessory.getService(device.Name + " Temperature");
     InsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.CurrentTemperature);
-
-    // Fakegato Support
-    accessory.context.logEventCounter++;
-    if (!(accessory.context.logEventCounter % 10)) {
-      accessory.loggingService.addEntry({
-        time: moment().unix(),
-        temp: device.CurrentTemperature
-      });
-      accessory.context.logEventCounter = 0;
-    }
   }
   if (accessory.getService("Outside Temperature")) {
     //debug("updateStatus() " + device.Name + " outsideTemperature = true");
@@ -192,16 +182,6 @@ function updateStatus(accessory, device) {
     var InsideHumidity = accessory.getService(device.Name + " Humidity");
     InsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)
       .updateValue(device.InsideHumidity);
-
-    // Fakegato Support
-    accessory.context.logEventCounter++;
-    if (!(accessory.context.logEventCounter % 10)) {
-      accessory.loggingService.addEntry({
-        time: moment().unix(),
-        humidity: device.InsideHumidity
-      });
-      accessory.context.logEventCounter = 0;
-    }
   }
   if (accessory.getService("Outside Humidity")) {
     //debug("updateStatus() " + device.Name + " outsideHumidity = true");
@@ -255,7 +235,7 @@ function updateStatus(accessory, device) {
 
 function TccAccessory(that, device, sensors) {
   this.log = that.log;
-  this.log("Adding TCC Device", device.Name);
+  //this.log("Adding TCC Device", device.Name);
   this.name = device.Name;
   this.ThermostatID = device.ThermostatID;
   this.device = device;
@@ -411,7 +391,7 @@ function TccAccessory(that, device, sensors) {
 
 function TccSensorsAccessory(that, device, sensors) {
   this.log = that.log;
-  this.log("Adding TCC Sensors Device");
+  //this.log("Adding TCC Sensors Device");
   this.name = "Outside Sensors"
   this.ThermostatID = device.ThermostatID;
   this.device = device;
@@ -451,7 +431,7 @@ function TccSensorsAccessory(that, device, sensors) {
     this.OutsideHumidityService
       .getCharacteristic(Characteristic.CurrentRelativeHumidity);
 
-    this.accessory.loggingService = new FakeGatoHistoryService("thermo", this.accessory, {
+    this.accessory.loggingService = new FakeGatoHistoryService("weather", this.accessory, {
       storage: this.storage,
       minutes: this.refresh * 10 / 60
     });

--- a/index.js
+++ b/index.js
@@ -348,9 +348,10 @@ function TccAccessory(that, device, config) {
     
     // need to check if accessory already exists, but user added temp/humidity sensors then must declare
     this.accessory = getAccessoryByThermostatID(this.ThermostatID);
+    debug("TccAccessory() " + this.name + " getService('this.Name + Temperature')" + !this.accessory.getService(this.Name + " Temperature"));
     if ((thisDeviceConfig.insideTemperature || false)  && !this.accessory.getService(this.Name + " Temperature")) {
       debug("TccAccessory() " + this.name + " OutsideTemperature = true, adding sensor");
-      this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "INSIDE");
+      this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "Inside");
       
       this.InsideTemperatureService
         .getCharacteristic(Characteristic.CurrentTemperature)
@@ -359,9 +360,10 @@ function TccAccessory(that, device, config) {
           maxValue: 100
         });
     }
+    debug("TccAccessory() " + this.name + " getService('Outside Temperature')" + !this.accessory.getService("Outside Temperature"));
     if ((thisDeviceConfig.outsideTemperature || false)  && !this.accessory.getService("Outside Temperature")) {
       debug("TccAccessory() " + this.name + " OutsideTemperature = true, adding sensor");
-      this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "OUTSIDE");
+      this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "Outside");
       
       this.OutsideTemperatureService
         .getCharacteristic(Characteristic.CurrentTemperature)
@@ -370,16 +372,18 @@ function TccAccessory(that, device, config) {
           maxValue: 100
         });
     }
+    debug("TccAccessory() " + this.name + " getService('this.Name + Humidity')" + !this.accessory.getService(this.Name + " Humidity"));
     if ((thisDeviceConfig.insideHumidity || false)  && !this.accessory.getService(this.Name + " Humidity")) {
       debug("TccAccessory() " + this.name + " InsideHumidity = true, adding sensor");
-      this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "INSIDE");
+      this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "Inside");
       
       this.InsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);
     }
+    debug("TccAccessory() " + this.name + " getService('Outside Humidity')" + !this.accessory.getService("Outside Humidity"));
     if ((thisDeviceConfig.outsideHumidity || false) && !this.accessory.getService("Outside Humidity")) {
       debug("TccAccessory() " + this.name + " outsideHumidity = true, adding sensor");
-      this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "OUTSIDE");
+      this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "Outside");
       
       this.OutsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ function updateStatus(accessory, device) {
   var service = accessory.getService(Service.Thermostat);
 
   // push config settings for this thermostat along with next function
-  this.log("updateStatus()", this.devices);
+  debug("updateStatus()", this.devices);
   for (var deviceConfig in this.devices) {
     if (deviceConfig.deviceID == accessory.context.ThermostatID) {
       this.deviceConfig = deviceConfig;

--- a/index.js
+++ b/index.js
@@ -156,25 +156,25 @@ function updateStatus(accessory, device, config) {
   debug("updateStatus() - insideHumidity:",thisDeviceConfig.insideHumidity);
   debug("updateStatus() - outsideHumidity:",thisDeviceConfig.outsideHumidity);
   if (thisDeviceConfig.insideTemperature || false) {
-    debug("updateStatus() - device.Name - InsideTemperature = true");
+    debug("updateStatus()" + device.Name + "InsideTemperature = true");
     var InsideTemperature = accessory.getService(device.Name + "Temperature");
     InsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.CurrentTemperature);
   }
   if (thisDeviceConfig.outsideTemperature || false) {
-    debug("updateStatus() - device.Name - OutsideTemperature = true");
+    debug("updateStatus()" + device.Name + "outsideTemperature = true");
     var OutsideTemperature = accessory.getService("Outside Temperature");
     OutsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.OutsideTemperature);
   }
   if (thisDeviceConfig.insideHumidity || false) {
-    debug("updateStatus() - device.Name - InsideHumidity = true");
+    debug("updateStatus()" + device.Name + "insideHumidity = true");
     var InsideHumidity = accessory.getService(device.Name + "Humidity");
     InsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)
       .updateValue(device.InsideHumidity);
   }
   if (thisDeviceConfig.outsideHumidity || false) {
-    debug("updateStatus() - device.Name - OutsideHumidity = true");
+    debug("updateStatus()" + device.Name + "outsideHumidity = true");
     var OutsideHumidity = accessory.getService("Outside Humidity");
 
     OutsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)
@@ -250,7 +250,7 @@ function TccAccessory(that, device, config) {
     debug("TccAccessory() - insideHumidity:",thisDeviceConfig.insideHumidity);
     debug("TccAccessory() - outsideHumidity:",thisDeviceConfig.outsideHumidity);
     if (thisDeviceConfig.insideTemperature || false) {
-      debug("TccAccessory() - device.Name - InsideTemperature = true");
+      debug("TccAccessory()" + device.Name + "InsideTemperature = true");
       this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + "Temperature", "INSIDE");
       
       this.InsideTemperatureService
@@ -261,7 +261,7 @@ function TccAccessory(that, device, config) {
         });
     }
     if (thisDeviceConfig.outsideTemperature || false) {
-      debug("TccAccessory() - device.Name - outsideTemperature = true");
+      debug("TccAccessory()" + device.Name + "outsideTemperature = true");
       this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "OUTSIDE");
       
       this.OutsideTemperatureService
@@ -272,14 +272,14 @@ function TccAccessory(that, device, config) {
         });
     }
     if (thisDeviceConfig.insideHumidity || false) {
-      debug("TccAccessory() - device.Name - InsideHumidity = true");
+      debug("TccAccessory()" + device.Name + "insideHumidity = true");
       this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + "Humidity", "INSIDE");
       
       this.InsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);
     }
     if (thisDeviceConfig.outsideHumidity || false) {
-      debug("TccAccessory() - device.Name - OutsideHumidity = true");
+      debug("TccAccessory()" + device.Name + "outsideHumidity = true");
       this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "OUTSIDE");
       
       this.OutsideHumidityService
@@ -353,7 +353,46 @@ function TccAccessory(that, device, config) {
     return this.accessory;
   } else {
     this.log("Existing TCC accessory", this.name);
-    return getAccessoryByThermostatID(this.ThermostatID);
+    
+    // need to check if accessory already exists, but user added temp/humidity sensors then must declare
+    this.accessory = getAccessoryByThermostatID(this.ThermostatID);
+    if (thisDeviceConfig.insideTemperature && !this.accessory.getService(this.Name + "Temperature")) {
+      debug("TccAccessory()" + this.Name + "OutsideTemperature = true, adding sensor");
+      this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + "Temperature", "INSIDE");
+      
+      this.InsideTemperatureService
+        .getCharacteristic(Characteristic.CurrentTemperature)
+        .setProps({
+          minValue: -100, // If you need this, you have major problems!!!!!
+          maxValue: 100
+        });
+    }
+    if (thisDeviceConfig.outsideTemperature && !this.accessory.getService("Outside Temperature")) {
+      debug("TccAccessory()" + this.Name + "OutsideTemperature = true, adding sensor");
+      this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "OUTSIDE");
+      
+      this.OutsideTemperatureService
+        .getCharacteristic(Characteristic.CurrentTemperature)
+        .setProps({
+          minValue: -100, // If you need this, you have major problems!!!!!
+          maxValue: 100
+        });
+    }
+    if (thisDeviceConfig.insideHumidity && !this.accessory.getService(this.Name + "Humidity")) {
+      debug("TccAccessory()" + this.Name + "InsideHumidity = true, adding sensor");
+      this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + "Humidity", "INSIDE");
+      
+      this.InsideHumidityService
+        .getCharacteristic(Characteristic.CurrentRelativeHumidity);
+    }
+    if (thisDeviceConfig.outsideHumidity && !this.accessory.getService("Outside Humidity")) {
+      debug("TccAccessory()" + this.Name + "outsideHumidity = true, adding sensor");
+      this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "OUTSIDE");
+      
+      this.OutsideHumidityService
+        .getCharacteristic(Characteristic.CurrentRelativeHumidity);
+    }
+    return this.accessory;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -143,27 +143,27 @@ function updateStatus(accessory, device, config) {
   debug("updateStatus()", config);
   config.forEach(function(deviceConfig) {
     if (deviceConfig.deviceID == accessory.context.ThermostatID) {
-      this.deviceConfig = deviceConfig;
+      var thisDeviceConfig = deviceConfig;
     }
   });
 
   // check if user wants separate temperature and humidity sensors
-  if (this.deviceConfig.insideTemperature || false) {
+  if (thisDeviceConfig.insideTemperature || false) {
     var InsideTemperature = accessory.getService(device.Name + "Temperature");
     InsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.CurrentTemperature);
   }
-  if (this.deviceConfig.outsideTemperature || false) {
+  if (thisDeviceConfig.outsideTemperature || false) {
     var OutsideTemperature = accessory.getService("Outside Temperature");
     OutsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.OutsideTemperature);
   }
-  if (this.deviceConfig.insideHumidity || false) {
+  if (thisDeviceConfig.insideHumidity || false) {
     var InsideHumidity = accessory.getService(device.Name + "Humidity");
     InsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)
       .updateValue(device.InsideHumidity);
   }
-  if (this.deviceConfig.outsideHumidity || false) {
+  if (thisDeviceConfig.outsideHumidity || false) {
     var OutsideHumidity = accessory.getService("Outside Humidity");
 
     OutsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)
@@ -208,7 +208,7 @@ function TccAccessory(that, device) {
   this.storage = that.storage;
   this.refresh = that.refresh;
   this.devices = that.devices;
-  this.log("TccAccessory()" + this.devices);
+  this.log("TccAccessory()" + that.devices);
   
   var uuid = UUIDGen.generate(this.name + " - TCC");
 

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ tccPlatform.prototype.configureAccessory = function(accessory) {
   
   // add fakegato logging for 
   debug(accessory);
-  if (accessory.getService("Outside Humidity") | accessory.getService("Outside Temperature")) {
+  if (accessory.getService(Service.HumiditySensor) | accessory.getService(Service.TemperatureSensor) & (accessory.getService(Service.HumiditySensor).displayName == "Outside Humidity" | accessory.getService(Service.TemperatureSensor).displayName == "Outside Temperature")) {
     debug("FakeGatoHistoryService", this.storage, this.refresh);
     accessory.context.logEventCounter = 9; // Update fakegato on startup
     accessory.loggingService = new FakeGatoHistoryService("weather", accessory, {

--- a/index.js
+++ b/index.js
@@ -151,30 +151,26 @@ function updateStatus(accessory, device, config) {
   }
 
   // check if user wants separate temperature and humidity sensors
-  debug("updateStatus() - insideTemperature:",thisDeviceConfig.insideTemperature);
-  debug("updateStatus() - outsideTemperature:",thisDeviceConfig.outsideTemperature);
-  debug("updateStatus() - insideHumidity:",thisDeviceConfig.insideHumidity);
-  debug("updateStatus() - outsideHumidity:",thisDeviceConfig.outsideHumidity);
   if (thisDeviceConfig.insideTemperature || false) {
-    debug("updateStatus()" + device.Name + "InsideTemperature = true");
-    var InsideTemperature = accessory.getService(device.Name + "Temperature");
+    debug("updateStatus() " + device.Name + " InsideTemperature = true");
+    var InsideTemperature = accessory.getService(device.Name + " Temperature");
     InsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.CurrentTemperature);
   }
   if (thisDeviceConfig.outsideTemperature || false) {
-    debug("updateStatus()" + device.Name + "outsideTemperature = true");
+    debug("updateStatus() " + device.Name + " outsideTemperature = true");
     var OutsideTemperature = accessory.getService("Outside Temperature");
     OutsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.OutsideTemperature);
   }
   if (thisDeviceConfig.insideHumidity || false) {
-    debug("updateStatus()" + device.Name + "insideHumidity = true");
-    var InsideHumidity = accessory.getService(device.Name + "Humidity");
+    debug("updateStatus() " + device.Name + " insideHumidity = true");
+    var InsideHumidity = accessory.getService(device.Name + " Humidity");
     InsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)
       .updateValue(device.InsideHumidity);
   }
   if (thisDeviceConfig.outsideHumidity || false) {
-    debug("updateStatus()" + device.Name + "outsideHumidity = true");
+    debug("updateStatus() " + device.Name + " outsideHumidity = true");
     var OutsideHumidity = accessory.getService("Outside Humidity");
 
     OutsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)
@@ -245,13 +241,9 @@ function TccAccessory(that, device, config) {
     this.accessory.addService(Service.Thermostat, this.name);
     
     // check if user wants separate temperature and humidity sensors by zone/thermostat
-    debug("TccAccessory() - insideTemperature:",thisDeviceConfig.insideTemperature);
-    debug("TccAccessory() - outsideTemperature:",thisDeviceConfig.outsideTemperature);
-    debug("TccAccessory() - insideHumidity:",thisDeviceConfig.insideHumidity);
-    debug("TccAccessory() - outsideHumidity:",thisDeviceConfig.outsideHumidity);
     if (thisDeviceConfig.insideTemperature || false) {
-      debug("TccAccessory()" + device.Name + "InsideTemperature = true");
-      this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + "Temperature", "INSIDE");
+      debug("TccAccessory() " + this.Name + " InsideTemperature = true");
+      this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "INSIDE");
       
       this.InsideTemperatureService
         .getCharacteristic(Characteristic.CurrentTemperature)
@@ -261,7 +253,7 @@ function TccAccessory(that, device, config) {
         });
     }
     if (thisDeviceConfig.outsideTemperature || false) {
-      debug("TccAccessory()" + device.Name + "outsideTemperature = true");
+      debug("TccAccessory() " + this.Name + " outsideTemperature = true");
       this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "OUTSIDE");
       
       this.OutsideTemperatureService
@@ -272,14 +264,14 @@ function TccAccessory(that, device, config) {
         });
     }
     if (thisDeviceConfig.insideHumidity || false) {
-      debug("TccAccessory()" + device.Name + "insideHumidity = true");
-      this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + "Humidity", "INSIDE");
+      debug("TccAccessory() " + this.Name + " insideHumidity = true");
+      this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "INSIDE");
       
       this.InsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);
     }
     if (thisDeviceConfig.outsideHumidity || false) {
-      debug("TccAccessory()" + device.Name + "outsideHumidity = true");
+      debug("TccAccessory() " + this.Name + " outsideHumidity = true");
       this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "OUTSIDE");
       
       this.OutsideHumidityService
@@ -356,9 +348,9 @@ function TccAccessory(that, device, config) {
     
     // need to check if accessory already exists, but user added temp/humidity sensors then must declare
     this.accessory = getAccessoryByThermostatID(this.ThermostatID);
-    if (thisDeviceConfig.insideTemperature && !this.accessory.getService(this.Name + "Temperature")) {
-      debug("TccAccessory()" + this.Name + "OutsideTemperature = true, adding sensor");
-      this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + "Temperature", "INSIDE");
+    if ((thisDeviceConfig.insideTemperature || false)  && !this.accessory.getService(this.Name + " Temperature")) {
+      debug("TccAccessory() " + this.Name + " OutsideTemperature = true, adding sensor");
+      this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "INSIDE");
       
       this.InsideTemperatureService
         .getCharacteristic(Characteristic.CurrentTemperature)
@@ -367,8 +359,8 @@ function TccAccessory(that, device, config) {
           maxValue: 100
         });
     }
-    if (thisDeviceConfig.outsideTemperature && !this.accessory.getService("Outside Temperature")) {
-      debug("TccAccessory()" + this.Name + "OutsideTemperature = true, adding sensor");
+    if ((thisDeviceConfig.outsideTemperature || false)  && !this.accessory.getService("Outside Temperature")) {
+      debug("TccAccessory() " + this.Name + " OutsideTemperature = true, adding sensor");
       this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "OUTSIDE");
       
       this.OutsideTemperatureService
@@ -378,15 +370,15 @@ function TccAccessory(that, device, config) {
           maxValue: 100
         });
     }
-    if (thisDeviceConfig.insideHumidity && !this.accessory.getService(this.Name + "Humidity")) {
-      debug("TccAccessory()" + this.Name + "InsideHumidity = true, adding sensor");
-      this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + "Humidity", "INSIDE");
+    if ((thisDeviceConfig.insideHumidity || false)  && !this.accessory.getService(this.Name + " Humidity")) {
+      debug("TccAccessory() " + this.Name + " InsideHumidity = true, adding sensor");
+      this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "INSIDE");
       
       this.InsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);
     }
-    if (thisDeviceConfig.outsideHumidity && !this.accessory.getService("Outside Humidity")) {
-      debug("TccAccessory()" + this.Name + "outsideHumidity = true, adding sensor");
+    if ((thisDeviceConfig.outsideHumidity || false) && !this.accessory.getService("Outside Humidity")) {
+      debug("TccAccessory() " + this.Name + " outsideHumidity = true, adding sensor");
       this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "OUTSIDE");
       
       this.OutsideHumidityService

--- a/index.js
+++ b/index.js
@@ -348,8 +348,8 @@ function TccAccessory(that, device, config) {
     
     // need to check if accessory/zone/thermostat already exists, but user added temp/humidity sensors then must declare
     this.accessory = getAccessoryByThermostatID(this.ThermostatID);
-    debug("TccAccessory() " + this.name + " getService('this.Name + Temperature')" + this.accessory.getService(this.Name + " Temperature"));
-    if ((thisDeviceConfig.insideTemperature || false)  && !this.accessory.getService(this.Name + " Temperature")) {
+    debug("TccAccessory() " + this.name + " getService('this.name + Temperature')" + !this.accessory.getService(this.name + " Temperature"));
+    if ((thisDeviceConfig.insideTemperature || false)  && !this.accessory.getService(this.name + " Temperature")) {
       debug("TccAccessory() " + this.name + " InsideTemperature = true, adding sensor");
       this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "Inside");
       
@@ -360,7 +360,7 @@ function TccAccessory(that, device, config) {
           maxValue: 100
         });
     }
-    debug("TccAccessory() " + this.name + " getService('Outside Temperature')" + this.accessory.getService("Outside Temperature"));
+    debug("TccAccessory() " + this.name + " getService('Outside Temperature')" + !this.accessory.getService("Outside Temperature"));
     if ((thisDeviceConfig.outsideTemperature || false)  && !this.accessory.getService("Outside Temperature")) {
       debug("TccAccessory() " + this.name + " OutsideTemperature = true, adding sensor");
       this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "Outside");
@@ -372,15 +372,15 @@ function TccAccessory(that, device, config) {
           maxValue: 100
         });
     }
-    debug("TccAccessory() " + this.name + " getService('this.Name + Humidity')" + this.accessory.getService(this.Name + " Humidity"));
-    if ((thisDeviceConfig.insideHumidity || false)  && !this.accessory.getService(this.Name + " Humidity")) {
+    debug("TccAccessory() " + this.name + " getService('this.name + Humidity')" + !this.accessory.getService(this.name + " Humidity"));
+    if ((thisDeviceConfig.insideHumidity || false)  && !this.accessory.getService(this.name + " Humidity")) {
       debug("TccAccessory() " + this.name + " InsideHumidity = true, adding sensor");
       this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "Inside");
       
       this.InsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);
     }
-    debug("TccAccessory() " + this.name + " getService('Outside Humidity')" + this.accessory.getService("Outside Humidity"));
+    debug("TccAccessory() " + this.name + " getService('Outside Humidity')" + !this.accessory.getService("Outside Humidity"));
     if ((thisDeviceConfig.outsideHumidity || false) && !this.accessory.getService("Outside Humidity")) {
       debug("TccAccessory() " + this.name + " outsideHumidity = true, adding sensor");
       this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "Outside");

--- a/index.js
+++ b/index.js
@@ -212,7 +212,8 @@ function TccAccessory(that, device, sensors, advanced) {
   var uuid = UUIDGen.generate(this.name + " - TCC");
   var createInsideSensors = false;
   var createOutsideSensors = false;
-
+  debug("outsideSensor count (" + this.name + "): " + outsideSensors);
+  
   // need to get config for this thermostat id
   switch (sensors) {
     case "none":

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ tccPlatform.prototype.configureAccessory = function(accessory) {
   }
 
   myAccessories.push(accessory);
-  debug(accessory.context)
+  //debug(accessory.context)
 };
 
 function pollDevices() {

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ function updateStatus(accessory, device, config) {
 
   // push config settings for this thermostat along with next function
   debug("updateStatus()", config);
-  this.devices.forEach(function(deviceConfig) {
+  config.forEach(function(deviceConfig) {
     if (deviceConfig.deviceID == accessory.context.ThermostatID) {
       this.deviceConfig = deviceConfig;
     }

--- a/index.js
+++ b/index.js
@@ -400,7 +400,7 @@ function setTargetTemperature(value, callback) {
     TargetTemperature: value
   }).then((thermostat) => {
     // debug("setTargetTemperature", this, thermostat);
-    updateStatus(this, thermostat);
+    updateStatus(this, thermostat, null);
     callback(null, value);
   }).catch((error) => {
     callback(error);
@@ -414,7 +414,7 @@ function setTargetHeatingCooling(value, callback) {
     TargetHeatingCooling: value
   }).then((thermostat) => {
     // debug("setTargetHeatingCooling", this, thermostat);
-    updateStatus(this, thermostat);
+    updateStatus(this, thermostat, null);
     callback(null, value);
   }).catch((error) => {
     callback(error);
@@ -427,7 +427,7 @@ function setHeatingThresholdTemperature(value, callback) {
     HeatingThresholdTemperature: value
   }).then((thermostat) => {
     // debug("setTargetHeatingCooling", this, thermostat);
-    updateStatus(this, thermostat);
+    updateStatus(this, thermostat, null);
     callback(null, value);
   }).catch((error) => {
     callback(error);
@@ -440,7 +440,7 @@ function setCoolingThresholdTemperature(value, callback) {
     CoolingThresholdTemperature: value
   }).then((thermostat) => {
     // debug("setTargetHeatingCooling", this, thermostat);
-    updateStatus(this, thermostat);
+    updateStatus(this, thermostat, null);
     callback(null, value);
   }).catch((error) => {
     callback(error);

--- a/index.js
+++ b/index.js
@@ -156,18 +156,48 @@ function updateStatus(accessory, device) {
     var InsideTemperature = accessory.getService(device.Name + " Temperature");
     InsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.CurrentTemperature);
+
+    // Fakegato Support
+    accessory.context.logEventCounter++;
+    if (!(accessory.context.logEventCounter % 10)) {
+      accessory.loggingService.addEntry({
+        time: moment().unix(),
+        temp: device.CurrentTemperature
+      });
+      accessory.context.logEventCounter = 0;
+    }
   }
   if (accessory.getService("Outside Temperature")) {
     //debug("updateStatus() " + device.Name + " outsideTemperature = true");
     var OutsideTemperature = accessory.getService("Outside Temperature");
     OutsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.OutsideTemperature);
+
+    // Fakegato Support
+    accessory.context.logEventCounter++;
+    if (!(accessory.context.logEventCounter % 10)) {
+      accessory.loggingService.addEntry({
+        time: moment().unix(),
+        temp: device.OutsideTemperature
+      });
+      accessory.context.logEventCounter = 0;
+    }
   }
   if (accessory.getService(device.Name + " Humidity")) {
     //debug("updateStatus() " + device.Name + " insideHumidity = true");
     var InsideHumidity = accessory.getService(device.Name + " Humidity");
     InsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)
       .updateValue(device.InsideHumidity);
+
+    // Fakegato Support
+    accessory.context.logEventCounter++;
+    if (!(accessory.context.logEventCounter % 10)) {
+      accessory.loggingService.addEntry({
+        time: moment().unix(),
+        humidity: device.InsideHumidity
+      });
+      accessory.context.logEventCounter = 0;
+    }
   }
   if (accessory.getService("Outside Humidity")) {
     //debug("updateStatus() " + device.Name + " outsideHumidity = true");
@@ -175,6 +205,16 @@ function updateStatus(accessory, device) {
 
     OutsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)
       .updateValue(device.OutsideHumidity);
+
+    // Fakegato Support
+    accessory.context.logEventCounter++;
+    if (!(accessory.context.logEventCounter % 10)) {
+      accessory.loggingService.addEntry({
+        time: moment().unix(),
+        humidity: device.OutsideHumidity
+      });
+      accessory.context.logEventCounter = 0;
+    }
   }
   
   if (accessory.getService(device.Name)) {
@@ -192,31 +232,31 @@ function updateStatus(accessory, device) {
       .updateValue(device.CoolingThresholdTemperature);
     service.getCharacteristic(Characteristic.HeatingThresholdTemperature)
       .updateValue(device.HeatingThresholdTemperature);
-  }
-  
-  // Fakegato Support
-  accessory.context.logEventCounter++;
-  if (!(accessory.context.logEventCounter % 10)) {
-    accessory.loggingService.addEntry({
-      time: moment().unix(),
-      currentTemp: device.CurrentTemperature,
-      setTemp: device.TargetTemperature,
-      valvePosition: device.CurrentHeatingCoolingState
-    });
-    accessory.context.logEventCounter = 0;
+      
+    // Fakegato Support
+    accessory.context.logEventCounter++;
+    if (!(accessory.context.logEventCounter % 10)) {
+      accessory.loggingService.addEntry({
+        time: moment().unix(),
+        currentTemp: device.CurrentTemperature,
+        setTemp: device.TargetTemperature,
+        valvePosition: device.CurrentHeatingCoolingState
+      });
+      accessory.context.logEventCounter = 0;
+    }
   }
 }
 
 function TccAccessory(that, device, sensors) {
   this.log = that.log;
-  this.log("Adding TCC Device", device.Name);
+  //this.log("Adding TCC Device", device.Name);
   this.name = device.Name;
   this.ThermostatID = device.ThermostatID;
   this.device = device;
   this.usePermanentHolds = that.usePermanentHolds;
   this.storage = that.storage;
   this.refresh = that.refresh;
-  debug("TccAccessory()",device);
+  //debug("TccAccessory()",device);
   
   var uuid = UUIDGen.generate(this.name + " - TCC");
   var createInsideSensors = false;
@@ -364,13 +404,13 @@ function TccAccessory(that, device, sensors) {
 
 function TccSensorsAccessory(that, device, sensors) {
   this.log = that.log;
-  this.log("Adding TCC Sensors Device");
+  //this.log("Adding TCC Sensors Device");
   this.name = "Outside Sensors"
   this.ThermostatID = device.ThermostatID;
   this.device = device;
   this.storage = that.storage;
   this.refresh = that.refresh;
-  debug("TccSensorsAccessory()",device);
+  //debug("TccSensorsAccessory()",device);
   
   var uuid = UUIDGen.generate(this.name + " - TCC");
   

--- a/index.js
+++ b/index.js
@@ -145,25 +145,25 @@ function updateStatus(accessory, device) {
 
   // check if user wants separate temperature and humidity sensors
   if (accessory.getService(device.Name + " Temperature")) {
-    debug("updateStatus() " + device.Name + " InsideTemperature = true");
+    //debug("updateStatus() " + device.Name + " InsideTemperature = true");
     var InsideTemperature = accessory.getService(device.Name + " Temperature");
     InsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.CurrentTemperature);
   }
   if (accessory.getService("Outside Temperature")) {
-    debug("updateStatus() " + device.Name + " outsideTemperature = true");
+    //debug("updateStatus() " + device.Name + " outsideTemperature = true");
     var OutsideTemperature = accessory.getService("Outside Temperature");
     OutsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.OutsideTemperature);
   }
   if (accessory.getService(device.Name + " Humidity")) {
-    debug("updateStatus() " + device.Name + " insideHumidity = true");
+    //debug("updateStatus() " + device.Name + " insideHumidity = true");
     var InsideHumidity = accessory.getService(device.Name + " Humidity");
     InsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)
       .updateValue(device.InsideHumidity);
   }
   if (accessory.getService("Outside Humidity")) {
-    debug("updateStatus() " + device.Name + " outsideHumidity = true");
+    //debug("updateStatus() " + device.Name + " outsideHumidity = true");
     var OutsideHumidity = accessory.getService("Outside Humidity");
 
     OutsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)

--- a/index.js
+++ b/index.js
@@ -151,25 +151,25 @@ function updateStatus(accessory, device, config) {
   }
 
   // check if user wants separate temperature and humidity sensors
-  if (thisDeviceConfig.insideTemperature || false) {
+  if ((thisDeviceConfig.insideTemperature || false) && accessory.getService(device.Name + " Temperature")) {
     debug("updateStatus() " + device.Name + " InsideTemperature = true");
     var InsideTemperature = accessory.getService(device.Name + " Temperature");
     InsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.CurrentTemperature);
   }
-  if (thisDeviceConfig.outsideTemperature || false) {
+  if ((thisDeviceConfig.outsideTemperature || false) && accessory.getService("Outside Temperature")) {
     debug("updateStatus() " + device.Name + " outsideTemperature = true");
     var OutsideTemperature = accessory.getService("Outside Temperature");
     OutsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.OutsideTemperature);
   }
-  if (thisDeviceConfig.insideHumidity || false) {
+  if ((thisDeviceConfig.insideHumidity || false) && accessory.getService(device.Name + " Humidity")) {
     debug("updateStatus() " + device.Name + " insideHumidity = true");
     var InsideHumidity = accessory.getService(device.Name + " Humidity");
     InsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)
       .updateValue(device.InsideHumidity);
   }
-  if (thisDeviceConfig.outsideHumidity || false) {
+  if ((thisDeviceConfig.outsideHumidity || false) && accessory.getService("Outside Humidity")) {
     debug("updateStatus() " + device.Name + " outsideHumidity = true");
     var OutsideHumidity = accessory.getService("Outside Humidity");
 

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ tccPlatform.prototype.didFinishLaunching = function() {
       debug("Creating accessory for", devices.hb[zone].ThermostatID);
       debug("tccPlatform.prototype.didFinishLaunching()",this.devices)
       var newAccessory = new TccAccessory(this, devices.hb[zone]);
-      updateStatus(newAccessory, devices.hb[zone]);
+      updateStatus(newAccessory, devices.hb[zone], this.devices);
     }
   }).catch((err) => {
     this.log("Critical Error - No devices created, please restart.");
@@ -143,11 +143,12 @@ function updateStatus(accessory, device, config) {
 
   // push config settings for this thermostat along with next function
   debug("updateStatus()", config);
-  config.forEach(function(deviceConfig) {
-    if (deviceConfig.deviceID == accessory.context.ThermostatID) {
-      var thisDeviceConfig = deviceConfig;
+  debug("updateStatus()", config.length);
+  for (let i = 0; i < config.length; i++) {
+    if (deviceConfig[i].deviceID == accessory.context.ThermostatID) {
+      var thisDeviceConfig = deviceConfig[i];
     }
-  });
+  }
 
   // check if user wants separate temperature and humidity sensors
   if (thisDeviceConfig.insideTemperature || false) {
@@ -210,17 +211,17 @@ function TccAccessory(that, device) {
   this.storage = that.storage;
   this.refresh = that.refresh;
   this.devices = that.devices;
-  this.log("TccAccessory()" + that.usePermanentHolds);
-  this.log("TccAccessory()" + that.devices);
+  debug("TccAccessory()" + that.usePermanentHolds);
+  debug("TccAccessory()" + that.devices);
   
   var uuid = UUIDGen.generate(this.name + " - TCC");
 
   // need to get config for this thermostat id
-  this.devices.forEach(function(deviceConfig) {
-    if (deviceConfig.deviceID == device.ThermostatID) {
-      this.deviceConfig = deviceConfig;
+  for (let i = 0; i < config.length; i++) {
+    if (deviceConfig[i].deviceID == accessory.context.ThermostatID) {
+      var thisDeviceConfig = deviceConfig[i];
     }
-  });
+  }
 
   if (!getAccessoryByThermostatID(this.ThermostatID)) {
     this.log("Adding TCC Device", this.name);

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ tccPlatform.prototype.configureAccessory = function(accessory) {
 
 function pollDevices() {
   thermostats.pollThermostat().then((devices) => {
-    this.log("pollDevices():" + this.config);
+    this.log("pollDevices():", this.config);
     myAccessories.forEach(function(accessory) {
       debug("pollDevices - updateStatus", accessory.displayName);
       if (devices.hb[accessory.context.ThermostatID]) {

--- a/index.js
+++ b/index.js
@@ -166,16 +166,6 @@ function updateStatus(accessory, device) {
     var OutsideTemperature = accessory.getService("Outside Temperature");
     OutsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.OutsideTemperature);
-
-    // Fakegato Support
-    accessory.context.logEventCounter++;
-    if (!(accessory.context.logEventCounter % 10)) {
-      accessory.loggingService.addEntry({
-        time: moment().unix(),
-        temp: device.OutsideTemperature
-      });
-      accessory.context.logEventCounter = 0;
-    }
   }
   if (accessory.getService(device.Name + " Humidity")) {
     //debug("updateStatus() " + device.Name + " insideHumidity = true");
@@ -189,18 +179,45 @@ function updateStatus(accessory, device) {
 
     OutsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)
       .updateValue(device.OutsideHumidity);
-
-    // Fakegato Support
+  }
+  
+  // fakegato for outside sensor
+  if (accessory.getService("Outside Humidity") & accessory.getService("Outside Temperature")) {
     accessory.context.logEventCounter++;
     if (!(accessory.context.logEventCounter % 10)) {
       accessory.loggingService.addEntry({
         time: moment().unix(),
-        humidity: device.OutsideHumidity
+        humidity: device.OutsideHumidity,
+        temp: device.OutsideTemperature,
+        pressure: 0
+      });
+      accessory.context.logEventCounter = 0;
+    }
+  }
+  else if (accessory.getService("Outside Humidity")) {    accessory.context.logEventCounter++;
+    if (!(accessory.context.logEventCounter % 10)) {
+      accessory.loggingService.addEntry({
+        time: moment().unix(),
+        humidity: device.OutsideHumidity,
+        temp: 0,
+        pressure: 0
+      });
+      accessory.context.logEventCounter = 0;
+    }
+  }
+  else if (accessory.getService("Outside Temperature")) {    accessory.context.logEventCounter++;
+    if (!(accessory.context.logEventCounter % 10)) {
+      accessory.loggingService.addEntry({
+        time: moment().unix(),
+        humidity: 0,
+        temp: device.OutsideTemperature,
+        pressure: 0
       });
       accessory.context.logEventCounter = 0;
     }
   }
   
+  // update thermostat
   if (accessory.getService(device.Name)) {
     var service = accessory.getService(Service.Thermostat);
     

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ function pollDevices() {
         this.log("ERROR: no data for", accessory.displayName);
         // debug("accessory", accessory);
         
-        if (accessory.getService(Service.Thermostat) {
+        if (accessory.getService(Service.Thermostat)) {
           accessory.getService(Service.Thermostat).getCharacteristic(Characteristic.TargetTemperature)
             .updateValue(new Error("Status missing for thermostat"));
           }
@@ -139,7 +139,7 @@ function pollDevices() {
       this.log("ERROR: pollDevices", err);
     }
     myAccessories.forEach(function(accessory) {
-      if (accessory.getService(Service.Thermostat) {
+      if (accessory.getService(Service.Thermostat)) {
         accessory.getService(Service.Thermostat).getCharacteristic(Characteristic.TargetTemperature)
           .updateValue(new Error("Status missing for thermostat"));
         }

--- a/index.js
+++ b/index.js
@@ -103,6 +103,7 @@ tccPlatform.prototype.configureAccessory = function(accessory) {
 
 function pollDevices() {
   thermostats.pollThermostat().then((devices) => {
+    this.log("pollDevices():" + this.config);
     myAccessories.forEach(function(accessory) {
       debug("pollDevices - updateStatus", accessory.displayName);
       if (devices.hb[accessory.context.ThermostatID]) {

--- a/index.js
+++ b/index.js
@@ -141,11 +141,11 @@ function updateStatus(accessory, device, config) {
 
   // push config settings for this thermostat along with next function
   debug("updateStatus()", config);
-  for (var deviceConfig in config) {
+  this.devices.forEach(function(deviceConfig) {
     if (deviceConfig.deviceID == accessory.context.ThermostatID) {
       this.deviceConfig = deviceConfig;
     }
-  }
+  });
 
   // check if user wants separate temperature and humidity sensors
   if (this.deviceConfig.insideTemperature || false) {
@@ -213,11 +213,11 @@ function TccAccessory(that, device) {
   var uuid = UUIDGen.generate(this.name + " - TCC");
 
   // need to get config for this thermostat id
-  for (var deviceConfig in this.devices) {
+  this.devices.forEach(function(deviceConfig) {
     if (deviceConfig.deviceID == this.ThermostatID) {
       this.deviceConfig = deviceConfig;
     }
-  }
+  });
 
   if (!getAccessoryByThermostatID(this.ThermostatID)) {
     this.log("Adding TCC Device", this.name);

--- a/index.js
+++ b/index.js
@@ -156,21 +156,25 @@ function updateStatus(accessory, device, config) {
   debug("updateStatus() - insideHumidity:",thisDeviceConfig.insideHumidity);
   debug("updateStatus() - outsideHumidity:",thisDeviceConfig.outsideHumidity);
   if (thisDeviceConfig.insideTemperature || false) {
+    debug("updateStatus() - device.Name - InsideTemperature = true");
     var InsideTemperature = accessory.getService(device.Name + "Temperature");
     InsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.CurrentTemperature);
   }
   if (thisDeviceConfig.outsideTemperature || false) {
+    debug("updateStatus() - device.Name - OutsideTemperature = true");
     var OutsideTemperature = accessory.getService("Outside Temperature");
     OutsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.OutsideTemperature);
   }
   if (thisDeviceConfig.insideHumidity || false) {
+    debug("updateStatus() - device.Name - InsideHumidity = true");
     var InsideHumidity = accessory.getService(device.Name + "Humidity");
     InsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)
       .updateValue(device.InsideHumidity);
   }
   if (thisDeviceConfig.outsideHumidity || false) {
+    debug("updateStatus() - device.Name - OutsideHumidity = true");
     var OutsideHumidity = accessory.getService("Outside Humidity");
 
     OutsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)
@@ -246,6 +250,7 @@ function TccAccessory(that, device, config) {
     debug("TccAccessory() - insideHumidity:",thisDeviceConfig.insideHumidity);
     debug("TccAccessory() - outsideHumidity:",thisDeviceConfig.outsideHumidity);
     if (thisDeviceConfig.insideTemperature || false) {
+      debug("TccAccessory() - device.Name - InsideTemperature = true");
       this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + "Temperature", "INSIDE");
       
       this.InsideTemperatureService
@@ -256,6 +261,7 @@ function TccAccessory(that, device, config) {
         });
     }
     if (thisDeviceConfig.outsideTemperature || false) {
+      debug("TccAccessory() - device.Name - outsideTemperature = true");
       this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "OUTSIDE");
       
       this.OutsideTemperatureService
@@ -266,12 +272,14 @@ function TccAccessory(that, device, config) {
         });
     }
     if (thisDeviceConfig.insideHumidity || false) {
+      debug("TccAccessory() - device.Name - InsideHumidity = true");
       this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + "Humidity", "INSIDE");
       
       this.InsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);
     }
     if (thisDeviceConfig.outsideHumidity || false) {
+      debug("TccAccessory() - device.Name - OutsideHumidity = true");
       this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "OUTSIDE");
       
       this.OutsideHumidityService

--- a/index.js
+++ b/index.js
@@ -147,8 +147,6 @@ function updateStatus(accessory, device) {
     .updateValue(device.Name);
   accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.Model)
     .updateValue(device.Model);
-    
-  var service = accessory.getService(Service.Thermostat);
 
   // check if user wants separate temperature and humidity sensors
   if (accessory.getService(device.Name + " Temperature")) {
@@ -218,6 +216,8 @@ function updateStatus(accessory, device) {
   }
   
   if (accessory.getService(device.Name)) {
+    var service = accessory.getService(Service.Thermostat);
+    
     service.getCharacteristic(Characteristic.Name)
       .updateValue(device.Name);
     service.getCharacteristic(Characteristic.TargetTemperature)

--- a/index.js
+++ b/index.js
@@ -52,6 +52,8 @@ tccPlatform.prototype.didFinishLaunching = function() {
   thermostats.pollThermostat().then((devices) => {
     for (var zone in devices.hb) {
       debug("Creating accessory for", devices.hb[zone].Name);
+      debug("Creating accessory for", devices.hb[zone].ThermostatID);
+      debug("tccPlatform.prototype.didFinishLaunching()",this.devices)
       var newAccessory = new TccAccessory(this, devices.hb[zone]);
       updateStatus(newAccessory, devices.hb[zone]);
     }
@@ -208,13 +210,14 @@ function TccAccessory(that, device) {
   this.storage = that.storage;
   this.refresh = that.refresh;
   this.devices = that.devices;
+  this.log("TccAccessory()" + that.usePermanentHolds);
   this.log("TccAccessory()" + that.devices);
   
   var uuid = UUIDGen.generate(this.name + " - TCC");
 
   // need to get config for this thermostat id
   this.devices.forEach(function(deviceConfig) {
-    if (deviceConfig.deviceID == this.ThermostatID) {
+    if (deviceConfig.deviceID == device.ThermostatID) {
       this.deviceConfig = deviceConfig;
     }
   });

--- a/index.js
+++ b/index.js
@@ -106,8 +106,7 @@ function pollDevices() {
     myAccessories.forEach(function(accessory) {
       debug("pollDevices - updateStatus", accessory.displayName);
       if (devices.hb[accessory.context.ThermostatID]) {
-        var devicesConfig = this.devices;
-        updateStatus(accessory, devices.hb[accessory.context.ThermostatID]);
+        updateStatus(accessory, devices.hb[accessory.context.ThermostatID], this.devices);
       } else {
         this.log("ERROR: no data for", accessory.displayName);
         // debug("accessory", accessory);
@@ -141,8 +140,8 @@ function updateStatus(accessory, device, config) {
   var service = accessory.getService(Service.Thermostat);
 
   // push config settings for this thermostat along with next function
-  debug("updateStatus()", devicesConfig);
-  for (var deviceConfig in devicesConfig) {
+  debug("updateStatus()", config);
+  for (var deviceConfig in config) {
     if (deviceConfig.deviceID == accessory.context.ThermostatID) {
       this.deviceConfig = deviceConfig;
     }

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ tccPlatform.prototype.didFinishLaunching = function() {
     for (var zone in devices.hb) {
       debug("Creating accessory for", devices.hb[zone].Name);
       debug("Creating accessory for", devices.hb[zone].ThermostatID);
-      debug("tccPlatform.prototype.didFinishLaunching()",this.devices)
+      //debug("tccPlatform.prototype.didFinishLaunching()",this.devices)
       var newAccessory = new TccAccessory(this, devices.hb[zone], this.devices);
       updateStatus(newAccessory, devices.hb[zone], this.devices);
     }
@@ -142,8 +142,8 @@ function updateStatus(accessory, device, config) {
   var service = accessory.getService(Service.Thermostat);
 
   // push config settings for this thermostat along with next function
-  debug("updateStatus()", config);
-  debug("updateStatus()", config.length);
+  //debug("updateStatus()", config);
+  //debug("updateStatus()", config.length);
   for (let i = 0; i < config.length; i++) {
     if (config[i].deviceID == accessory.context.ThermostatID) {
       var thisDeviceConfig = config[i];
@@ -151,6 +151,10 @@ function updateStatus(accessory, device, config) {
   }
 
   // check if user wants separate temperature and humidity sensors
+  debug("updateStatus() - insideTemperature:",thisDeviceConfig.insideTemperature);
+  debug("updateStatus() - outsideTemperature:",thisDeviceConfig.outsideTemperature);
+  debug("updateStatus() - insideHumidity:",thisDeviceConfig.insideHumidity);
+  debug("updateStatus() - outsideHumidity:",thisDeviceConfig.outsideHumidity);
   if (thisDeviceConfig.insideTemperature || false) {
     var InsideTemperature = accessory.getService(device.Name + "Temperature");
     InsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
@@ -210,7 +214,7 @@ function TccAccessory(that, device, config) {
   this.usePermanentHolds = that.usePermanentHolds;
   this.storage = that.storage;
   this.refresh = that.refresh;
-  debug("TccAccessory()",config);
+  //debug("TccAccessory()",config);
   
   var uuid = UUIDGen.generate(this.name + " - TCC");
 
@@ -237,6 +241,10 @@ function TccAccessory(that, device, config) {
     this.accessory.addService(Service.Thermostat, this.name);
     
     // check if user wants separate temperature and humidity sensors by zone/thermostat
+    debug("TccAccessory() - insideTemperature:",thisDeviceConfig.insideTemperature);
+    debug("TccAccessory() - outsideTemperature:",thisDeviceConfig.outsideTemperature);
+    debug("TccAccessory() - insideHumidity:",thisDeviceConfig.insideHumidity);
+    debug("TccAccessory() - outsideHumidity:",thisDeviceConfig.outsideHumidity);
     if (thisDeviceConfig.insideTemperature || false) {
       this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + "Temperature", "INSIDE");
       

--- a/index.js
+++ b/index.js
@@ -110,8 +110,7 @@ tccPlatform.prototype.configureAccessory = function(accessory) {
   }
   
   // add fakegato logging for 
-  debug(accessory.getService("Outside Humidity"));
-  debug(accessory.getService("Outside Temperature"));
+  debug(accessory);
   if (accessory.getService("Outside Humidity") | accessory.getService("Outside Temperature")) {
     debug("FakeGatoHistoryService", this.storage, this.refresh);
     accessory.context.logEventCounter = 9; // Update fakegato on startup

--- a/index.js
+++ b/index.js
@@ -106,8 +106,8 @@ function pollDevices() {
     myAccessories.forEach(function(accessory) {
       debug("pollDevices - updateStatus", accessory.displayName);
       if (devices.hb[accessory.context.ThermostatID]) {
-        this.log("pollDevices()", this.devices);
-        updateStatus(accessory, devices.hb[accessory.context.ThermostatID]).bind(this);
+        var devicesConfig = this.devices;
+        updateStatus(accessory, devices.hb[accessory.context.ThermostatID]);
       } else {
         this.log("ERROR: no data for", accessory.displayName);
         // debug("accessory", accessory);
@@ -132,7 +132,7 @@ function pollDevices() {
   });
 }
 
-function updateStatus(accessory, device) {
+function updateStatus(accessory, device, config) {
   accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.Name)
     .updateValue(device.Name);
   accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.Model)
@@ -141,8 +141,8 @@ function updateStatus(accessory, device) {
   var service = accessory.getService(Service.Thermostat);
 
   // push config settings for this thermostat along with next function
-  debug("updateStatus()", this.devices);
-  for (var deviceConfig in this.devices) {
+  debug("updateStatus()", devicesConfig);
+  for (var deviceConfig in devicesConfig) {
     if (deviceConfig.deviceID == accessory.context.ThermostatID) {
       this.deviceConfig = deviceConfig;
     }

--- a/index.js
+++ b/index.js
@@ -289,6 +289,7 @@ function TccAccessory(that, device, sensors) {
     this.accessory = new Accessory(this.name, uuid, 10);
     this.accessory.log = that.log;
     this.accessory.context.ThermostatID = device.ThermostatID;
+    this.accessory.context.name = this.name;
     this.accessory.context.logEventCounter = 9; // Update fakegato on startup
 
     this.accessory.getService(Service.AccessoryInformation)

--- a/index.js
+++ b/index.js
@@ -212,6 +212,7 @@ function TccAccessory(that, device, sensors, advanced) {
   var uuid = UUIDGen.generate(this.name + " - TCC");
   var createInsideSensors = false;
   var createOutsideSensors = false;
+  var thisDeviceConfig = [{"insideTemperature":false,"insideHumidity":false,"outsideTemperature":false,"outsideHumidity":false}];
   debug("outsideSensor count (" + this.name + "): " + outsideSensors);
   
   // need to get config for this thermostat id
@@ -244,11 +245,10 @@ function TccAccessory(that, device, sensors, advanced) {
       // default no sensors and look to thisDeviceConfig directives for logic on which sensors to instantiate
       createInsideSensors = false;
       createOutsideSensors = false;
-      var thisDeviceConfig = [{"insideTemperature":false,"insideHumidity":false,"outsideTemperature":false,"outsideHumidity":false}];
       if (advanced.length > 0) {
         for (let i = 0; i < advanced.length; i++) {
           if (advanced[i].deviceID == this.ThermostatID) {
-            var thisDeviceConfig = advanced[i];
+            thisDeviceConfig = advanced[i];
           }
         }
       }

--- a/index.js
+++ b/index.js
@@ -121,8 +121,11 @@ function pollDevices() {
       } else {
         this.log("ERROR: no data for", accessory.displayName);
         // debug("accessory", accessory);
-        accessory.getService(Service.Thermostat).getCharacteristic(Characteristic.TargetTemperature)
-          .updateValue(new Error("Status missing for thermostat"));
+        
+        if (accessory.getService(Service.Thermostat) {
+          accessory.getService(Service.Thermostat).getCharacteristic(Characteristic.TargetTemperature)
+            .updateValue(new Error("Status missing for thermostat"));
+          }
       }
     }.bind(this));
   }).catch((err) => {
@@ -136,8 +139,10 @@ function pollDevices() {
       this.log("ERROR: pollDevices", err);
     }
     myAccessories.forEach(function(accessory) {
-      accessory.getService(Service.Thermostat).getCharacteristic(Characteristic.TargetTemperature)
-        .updateValue(new Error("Status missing for thermostat"));
+      if (accessory.getService(Service.Thermostat) {
+        accessory.getService(Service.Thermostat).getCharacteristic(Characteristic.TargetTemperature)
+          .updateValue(new Error("Status missing for thermostat"));
+        }
     });
   });
 }

--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ function TccAccessory(that, device, sensors, advanced) {
     
     // check if user wants separate temperature and humidity sensors by zone/thermostat
     if (createInsideSensors || (thisDeviceConfig.insideTemperature || false)) {
-      debug("TccAccessory() " + this.name + " InsideTemperature = true");
+      debug("TccAccessory() " + this.name + " InsideTemperature = true, existing sensor");
       this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "INSIDE");
       
       this.InsideTemperatureService
@@ -280,7 +280,7 @@ function TccAccessory(that, device, sensors, advanced) {
         });
     }
     if (createOutsideSensors || (thisDeviceConfig.outsideTemperature || false)) {
-      debug("TccAccessory() " + this.name + " outsideTemperature = true");
+      debug("TccAccessory() " + this.name + " outsideTemperature = true, existing sensor");
       this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "OUTSIDE");
       
       this.OutsideTemperatureService
@@ -291,14 +291,14 @@ function TccAccessory(that, device, sensors, advanced) {
         });
     }
     if (createInsideSensors || (thisDeviceConfig.insideHumidity || false)) {
-      debug("TccAccessory() " + this.name + " insideHumidity = true");
+      debug("TccAccessory() " + this.name + " insideHumidity = true, existing sensor");
       this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "INSIDE");
       
       this.InsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);
     }
     if (createOutsideSensors || (thisDeviceConfig.outsideHumidity || false)) {
-      debug("TccAccessory() " + this.name + " outsideHumidity = true");
+      debug("TccAccessory() " + this.name + " outsideHumidity = true, existing sensor");
       this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "OUTSIDE");
       
       this.OutsideHumidityService
@@ -375,7 +375,6 @@ function TccAccessory(that, device, sensors, advanced) {
     
     // need to check if accessory/zone/thermostat already exists, but user added temp/humidity sensors then must declare
     this.accessory = getAccessoryByThermostatID(this.ThermostatID);
-    debug("TccAccessory() " + this.name + " getService('this.name + Temperature')" + !this.accessory.getService(this.name + " Temperature"));
     if ((createInsideSensors || (thisDeviceConfig.insideTemperature || false))  && !this.accessory.getService(this.name + " Temperature")) {
       debug("TccAccessory() " + this.name + " InsideTemperature = true, adding sensor");
       this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "Inside");
@@ -387,7 +386,6 @@ function TccAccessory(that, device, sensors, advanced) {
           maxValue: 100
         });
     }
-    debug("TccAccessory() " + this.name + " getService('Outside Temperature')" + !this.accessory.getService("Outside Temperature"));
     if ((createOutsideSensors || (thisDeviceConfig.outsideTemperature || false))  && !this.accessory.getService("Outside Temperature")) {
       debug("TccAccessory() " + this.name + " OutsideTemperature = true, adding sensor");
       this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "Outside");
@@ -399,7 +397,6 @@ function TccAccessory(that, device, sensors, advanced) {
           maxValue: 100
         });
     }
-    debug("TccAccessory() " + this.name + " getService('this.name + Humidity')" + !this.accessory.getService(this.name + " Humidity"));
     if ((createInsideSensors || (thisDeviceConfig.insideHumidity || false))  && !this.accessory.getService(this.name + " Humidity")) {
       debug("TccAccessory() " + this.name + " InsideHumidity = true, adding sensor");
       this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "Inside");
@@ -407,7 +404,6 @@ function TccAccessory(that, device, sensors, advanced) {
       this.InsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);
     }
-    debug("TccAccessory() " + this.name + " getService('Outside Humidity')" + !this.accessory.getService("Outside Humidity"));
     if ((createOutsideSensors || (thisDeviceConfig.outsideHumidity || false)) && !this.accessory.getService("Outside Humidity")) {
       debug("TccAccessory() " + this.name + " outsideHumidity = true, adding sensor");
       this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "Outside");

--- a/index.js
+++ b/index.js
@@ -110,8 +110,7 @@ tccPlatform.prototype.configureAccessory = function(accessory) {
   }
   
   // add fakegato logging for 
-  debug(accessory);
-  if (accessory.getService(Service.HumiditySensor) | accessory.getService(Service.TemperatureSensor) & (accessory.getService(Service.HumiditySensor).displayName == "Outside Humidity" | accessory.getService(Service.TemperatureSensor).displayName == "Outside Temperature")) {
+  if (accessory.displayName == "Outside Sensors") {
     debug("FakeGatoHistoryService", this.storage, this.refresh);
     accessory.context.logEventCounter = 9; // Update fakegato on startup
     accessory.loggingService = new FakeGatoHistoryService("weather", accessory, {

--- a/index.js
+++ b/index.js
@@ -350,7 +350,7 @@ function TccAccessory(that, device, sensors) {
           maxValue: 100
         });
     }
-    if (createInsideSensors  && !this.accessory.getService(this.name + " Humidity")) {
+    if (createInsideSensors && !this.accessory.getService(this.name + " Humidity")) {
       debug("TccAccessory() " + this.name + " InsideHumidity = true, adding sensor");
       this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "Inside");
       
@@ -387,19 +387,19 @@ function TccSensorsAccessory(that, device, sensors) {
       .setCharacteristic(Characteristic.SerialNumber, hostname + "-" + this.name)
       .setCharacteristic(Characteristic.FirmwareRevision, require('./package.json').version);
     
-    // create outside sensors
+    // create outside temp sensor
     debug("TccSensorsAccessory() " + this.name + " outsideTemperature = true, existing sensor");
     this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "OUTSIDE");
-    
     this.OutsideTemperatureService
       .getCharacteristic(Characteristic.CurrentTemperature)
       .setProps({
         minValue: -100, // If you need this, you have major problems!!!!!
         maxValue: 100
       });
+    
+    // create outside humidity sensor
     debug("TccSensorsAccessory() " + this.name + " outsideHumidity = true, existing sensor");
     this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "OUTSIDE");
-    
     this.OutsideHumidityService
       .getCharacteristic(Characteristic.CurrentRelativeHumidity);
 
@@ -412,7 +412,7 @@ function TccSensorsAccessory(that, device, sensors) {
     myAccessories.push(this.accessory);
     return this.accessory;
   } else {
-    this.log("Existing TCC accessory (deviceID="+this.ThermostatID+")", this.name);
+    this.log("Existing TCC outside sensors accessory (deviceID="+this.ThermostatID+")", this.name);
     
     // need to check if accessory/zone/thermostat already exists, but user added temp/humidity sensors then must declare
     this.accessory = getAccessoryByName("Outside Sensors");

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ tccPlatform.prototype.didFinishLaunching = function() {
       debug("Creating accessory for", devices.hb[zone].ThermostatID);
       //debug("tccPlatform.prototype.didFinishLaunching()",this.devices)
       var newAccessory = new TccAccessory(this, devices.hb[zone], this.devices);
-      updateStatus(newAccessory, devices.hb[zone], this.devices);
+      updateStatus(newAccessory, devices.hb[zone]);
     }
   }).catch((err) => {
     this.log("Critical Error - No devices created, please restart.");
@@ -108,7 +108,7 @@ function pollDevices() {
     myAccessories.forEach(function(accessory) {
       debug("pollDevices - updateStatus", accessory.displayName);
       if (devices.hb[accessory.context.ThermostatID]) {
-        updateStatus(accessory, devices.hb[accessory.context.ThermostatID], this.devices);
+        updateStatus(accessory, devices.hb[accessory.context.ThermostatID]);
       } else {
         this.log("ERROR: no data for", accessory.displayName);
         // debug("accessory", accessory);
@@ -133,7 +133,7 @@ function pollDevices() {
   });
 }
 
-function updateStatus(accessory, device, config) {
+function updateStatus(accessory, device) {
   accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.Name)
     .updateValue(device.Name);
   accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.Model)
@@ -141,35 +141,26 @@ function updateStatus(accessory, device, config) {
     
   var service = accessory.getService(Service.Thermostat);
 
-  // push config settings for this thermostat along with next function
-  //debug("updateStatus()", config);
-  //debug("updateStatus()", config.length);
-  for (let i = 0; i < config.length; i++) {
-    if (config[i].deviceID == accessory.context.ThermostatID) {
-      var thisDeviceConfig = config[i];
-    }
-  }
-
   // check if user wants separate temperature and humidity sensors
-  if ((thisDeviceConfig.insideTemperature || false) && accessory.getService(device.Name + " Temperature")) {
+  if (accessory.getService(device.Name + " Temperature")) {
     debug("updateStatus() " + device.Name + " InsideTemperature = true");
     var InsideTemperature = accessory.getService(device.Name + " Temperature");
     InsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.CurrentTemperature);
   }
-  if ((thisDeviceConfig.outsideTemperature || false) && accessory.getService("Outside Temperature")) {
+  if (accessory.getService("Outside Temperature")) {
     debug("updateStatus() " + device.Name + " outsideTemperature = true");
     var OutsideTemperature = accessory.getService("Outside Temperature");
     OutsideTemperature.getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(device.OutsideTemperature);
   }
-  if ((thisDeviceConfig.insideHumidity || false) && accessory.getService(device.Name + " Humidity")) {
+  if (accessory.getService(device.Name + " Humidity")) {
     debug("updateStatus() " + device.Name + " insideHumidity = true");
     var InsideHumidity = accessory.getService(device.Name + " Humidity");
     InsideHumidity.getCharacteristic(Characteristic.CurrentRelativeHumidity)
       .updateValue(device.InsideHumidity);
   }
-  if ((thisDeviceConfig.outsideHumidity || false) && accessory.getService("Outside Humidity")) {
+  if (accessory.getService("Outside Humidity")) {
     debug("updateStatus() " + device.Name + " outsideHumidity = true");
     var OutsideHumidity = accessory.getService("Outside Humidity");
 
@@ -400,7 +391,7 @@ function setTargetTemperature(value, callback) {
     TargetTemperature: value
   }).then((thermostat) => {
     // debug("setTargetTemperature", this, thermostat);
-    updateStatus(this, thermostat, null);
+    updateStatus(this, thermostat);
     callback(null, value);
   }).catch((error) => {
     callback(error);
@@ -414,7 +405,7 @@ function setTargetHeatingCooling(value, callback) {
     TargetHeatingCooling: value
   }).then((thermostat) => {
     // debug("setTargetHeatingCooling", this, thermostat);
-    updateStatus(this, thermostat, null);
+    updateStatus(this, thermostat);
     callback(null, value);
   }).catch((error) => {
     callback(error);
@@ -427,7 +418,7 @@ function setHeatingThresholdTemperature(value, callback) {
     HeatingThresholdTemperature: value
   }).then((thermostat) => {
     // debug("setTargetHeatingCooling", this, thermostat);
-    updateStatus(this, thermostat, null);
+    updateStatus(this, thermostat);
     callback(null, value);
   }).catch((error) => {
     callback(error);
@@ -440,7 +431,7 @@ function setCoolingThresholdTemperature(value, callback) {
     CoolingThresholdTemperature: value
   }).then((thermostat) => {
     // debug("setTargetHeatingCooling", this, thermostat);
-    updateStatus(this, thermostat, null);
+    updateStatus(this, thermostat);
     callback(null, value);
   }).catch((error) => {
     callback(error);

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ tccPlatform.prototype.didFinishLaunching = function() {
       // does user want outside sensors created? if so, only create 1 set
       if ((this.sensors == "all" || this.sensors == "outside") && outsideSensors == 0) {
         var newSensorsAccessory = new TccSensorsAccessory(this, devices.hb[zone], this.sensors);
-        updateStatus(newAccessory, devices.hb[zone]);
+        updateStatus(newSensorsAccessory, devices.hb[zone]);
         outsideSensors = 1;
       }
     }

--- a/index.js
+++ b/index.js
@@ -145,8 +145,8 @@ function updateStatus(accessory, device, config) {
   debug("updateStatus()", config);
   debug("updateStatus()", config.length);
   for (let i = 0; i < config.length; i++) {
-    if (deviceConfig[i].deviceID == accessory.context.ThermostatID) {
-      var thisDeviceConfig = deviceConfig[i];
+    if (config[i].deviceID == accessory.context.ThermostatID) {
+      var thisDeviceConfig = config[i];
     }
   }
 
@@ -216,8 +216,8 @@ function TccAccessory(that, device, config) {
 
   // need to get config for this thermostat id
   for (let i = 0; i < config.length; i++) {
-    if (deviceConfig[i].deviceID == this.ThermostatID) {
-      var thisDeviceConfig = deviceConfig[i];
+    if (config[i].deviceID == this.ThermostatID) {
+      var thisDeviceConfig = config[i];
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@ tccPlatform.prototype.configureAccessory = function(accessory) {
   }
 
   myAccessories.push(accessory);
+  debug(accessory)
 };
 
 function pollDevices() {

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ tccPlatform.prototype.configureAccessory = function(accessory) {
   if (accessory.getService("Outside Humidity") | accessory.getService("Outside Temperature")) {
     debug("FakeGatoHistoryService", this.storage, this.refresh);
     accessory.context.logEventCounter = 9; // Update fakegato on startup
-    accessory.loggingService = new FakeGatoHistoryService("thermo", accessory, {
+    accessory.loggingService = new FakeGatoHistoryService("weather", accessory, {
       storage: this.storage,
       minutes: this.refresh * 10 / 60
     });

--- a/index.js
+++ b/index.js
@@ -108,7 +108,17 @@ tccPlatform.prototype.configureAccessory = function(accessory) {
     accessory.context.ChangeThermostat = new ChangeThermostat(accessory);
     debug("configureAccessory", accessory.context.ChangeThermostat);
   }
-
+  
+  // add fakegato logging for 
+  if (accessory.getService("Outside Humidity") | accessory.getService("Outside Temperature")) {
+    debug("FakeGatoHistoryService", this.storage, this.refresh);
+    accessory.context.logEventCounter = 9; // Update fakegato on startup
+    accessory.loggingService = new FakeGatoHistoryService("thermo", accessory, {
+      storage: this.storage,
+      minutes: this.refresh * 10 / 60
+    });
+  }
+  
   myAccessories.push(accessory);
   //debug(accessory.context)
 };
@@ -194,7 +204,8 @@ function updateStatus(accessory, device) {
       accessory.context.logEventCounter = 0;
     }
   }
-  else if (accessory.getService("Outside Humidity")) {    accessory.context.logEventCounter++;
+  else if (accessory.getService("Outside Humidity")) {
+    accessory.context.logEventCounter++;
     if (!(accessory.context.logEventCounter % 10)) {
       accessory.loggingService.addEntry({
         time: moment().unix(),
@@ -205,7 +216,8 @@ function updateStatus(accessory, device) {
       accessory.context.logEventCounter = 0;
     }
   }
-  else if (accessory.getService("Outside Temperature")) {    accessory.context.logEventCounter++;
+  else if (accessory.getService("Outside Temperature")) {
+    accessory.context.logEventCounter++;
     if (!(accessory.context.logEventCounter % 10)) {
       accessory.loggingService.addEntry({
         time: moment().unix(),
@@ -300,7 +312,7 @@ function TccAccessory(that, device, sensors) {
     // check if user wants separate temperature and humidity sensors by zone/thermostat
     if (createInsideSensors) {
       debug("TccAccessory() " + this.name + " InsideTemperature = true, existing sensor");
-      this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "INSIDE");
+      this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "Inside");
       this.InsideTemperatureService
         .getCharacteristic(Characteristic.CurrentTemperature)
         .setProps({
@@ -309,7 +321,7 @@ function TccAccessory(that, device, sensors) {
         });
         
       debug("TccAccessory() " + this.name + " insideHumidity = true, existing sensor");
-      this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "INSIDE");
+      this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "Inside");
       this.InsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);
     }
@@ -434,7 +446,7 @@ function TccSensorsAccessory(that, device, sensors) {
     
     // create outside temp sensor
     debug("TccSensorsAccessory() " + this.name + " outsideTemperature = true, existing sensor");
-    this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "OUTSIDE");
+    this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "Outside");
     this.OutsideTemperatureService
       .getCharacteristic(Characteristic.CurrentTemperature)
       .setProps({
@@ -444,7 +456,7 @@ function TccSensorsAccessory(that, device, sensors) {
     
     // create outside humidity sensor
     debug("TccSensorsAccessory() " + this.name + " outsideHumidity = true, existing sensor");
-    this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "OUTSIDE");
+    this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "Outside");
     this.OutsideHumidityService
       .getCharacteristic(Characteristic.CurrentRelativeHumidity);
 

--- a/index.js
+++ b/index.js
@@ -103,10 +103,12 @@ tccPlatform.prototype.configureAccessory = function(accessory) {
       storage: this.storage,
       minutes: this.refresh * 10 / 60
     });
+    
+    // only attach this to the actual thermostat accessories, not the sensors accessory
+    accessory.context.ChangeThermostat = new ChangeThermostat(accessory);
+    debug("configureAccessory", accessory.context.ChangeThermostat);
   }
 
-  accessory.context.ChangeThermostat = new ChangeThermostat(accessory);
-  // debug("CA", accessory.context.ChangeThermostat);
   myAccessories.push(accessory);
 };
 
@@ -207,14 +209,14 @@ function updateStatus(accessory, device) {
 
 function TccAccessory(that, device, sensors) {
   this.log = that.log;
-  // this.log("Adding TCC Device", device.DeviceName);
+  this.log("Adding TCC Device", device.DeviceName);
   this.name = device.Name;
   this.ThermostatID = device.ThermostatID;
   this.device = device;
   this.usePermanentHolds = that.usePermanentHolds;
   this.storage = that.storage;
   this.refresh = that.refresh;
-  //debug("TccAccessory()",config);
+  debug("TccAccessory()",config);
   
   var uuid = UUIDGen.generate(this.name + " - TCC");
   var createInsideSensors = false;
@@ -362,7 +364,7 @@ function TccAccessory(that, device, sensors) {
 
 function TccSensorsAccessory(that, device, sensors) {
   this.log = that.log;
-  // this.log("Adding TCC Device", device.DeviceName);
+  this.log("Adding TCC Device", device.DeviceName);
   this.name = "Outside Sensors"
   this.ThermostatID = device.ThermostatID;
   this.device = device;

--- a/index.js
+++ b/index.js
@@ -372,7 +372,7 @@ function TccAccessory(that, device, sensors) {
     this.log("Existing TCC accessory (deviceID="+this.ThermostatID+")", this.name);
     
     // need to check if accessory/zone/thermostat already exists, but user added temp/humidity sensors then must declare
-    this.accessory = getAccessoryByThermostatID(this.ThermostatID);
+    this.accessory = getAccessoryByName(this.name);
     if (createInsideSensors && !this.accessory.getService(this.name + " Temperature")) {
       debug("TccAccessory() " + this.name + " InsideTemperature = true, adding sensor");
       this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "Inside");

--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ function TccAccessory(that, device, sensors) {
   this.usePermanentHolds = that.usePermanentHolds;
   this.storage = that.storage;
   this.refresh = that.refresh;
-  debug("TccAccessory()",config);
+  debug("TccAccessory()",device);
   
   var uuid = UUIDGen.generate(this.name + " - TCC");
   var createInsideSensors = false;

--- a/index.js
+++ b/index.js
@@ -346,11 +346,11 @@ function TccAccessory(that, device, config) {
   } else {
     this.log("Existing TCC accessory", this.name);
     
-    // need to check if accessory already exists, but user added temp/humidity sensors then must declare
+    // need to check if accessory/zone/thermostat already exists, but user added temp/humidity sensors then must declare
     this.accessory = getAccessoryByThermostatID(this.ThermostatID);
-    debug("TccAccessory() " + this.name + " getService('this.Name + Temperature')" + !this.accessory.getService(this.Name + " Temperature"));
+    debug("TccAccessory() " + this.name + " getService('this.Name + Temperature')" + this.accessory.getService(this.Name + " Temperature"));
     if ((thisDeviceConfig.insideTemperature || false)  && !this.accessory.getService(this.Name + " Temperature")) {
-      debug("TccAccessory() " + this.name + " OutsideTemperature = true, adding sensor");
+      debug("TccAccessory() " + this.name + " InsideTemperature = true, adding sensor");
       this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "Inside");
       
       this.InsideTemperatureService
@@ -360,7 +360,7 @@ function TccAccessory(that, device, config) {
           maxValue: 100
         });
     }
-    debug("TccAccessory() " + this.name + " getService('Outside Temperature')" + !this.accessory.getService("Outside Temperature"));
+    debug("TccAccessory() " + this.name + " getService('Outside Temperature')" + this.accessory.getService("Outside Temperature"));
     if ((thisDeviceConfig.outsideTemperature || false)  && !this.accessory.getService("Outside Temperature")) {
       debug("TccAccessory() " + this.name + " OutsideTemperature = true, adding sensor");
       this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "Outside");
@@ -372,7 +372,7 @@ function TccAccessory(that, device, config) {
           maxValue: 100
         });
     }
-    debug("TccAccessory() " + this.name + " getService('this.Name + Humidity')" + !this.accessory.getService(this.Name + " Humidity"));
+    debug("TccAccessory() " + this.name + " getService('this.Name + Humidity')" + this.accessory.getService(this.Name + " Humidity"));
     if ((thisDeviceConfig.insideHumidity || false)  && !this.accessory.getService(this.Name + " Humidity")) {
       debug("TccAccessory() " + this.name + " InsideHumidity = true, adding sensor");
       this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "Inside");
@@ -380,7 +380,7 @@ function TccAccessory(that, device, config) {
       this.InsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);
     }
-    debug("TccAccessory() " + this.name + " getService('Outside Humidity')" + !this.accessory.getService("Outside Humidity"));
+    debug("TccAccessory() " + this.name + " getService('Outside Humidity')" + this.accessory.getService("Outside Humidity"));
     if ((thisDeviceConfig.outsideHumidity || false) && !this.accessory.getService("Outside Humidity")) {
       debug("TccAccessory() " + this.name + " outsideHumidity = true, adding sensor");
       this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "Outside");

--- a/index.js
+++ b/index.js
@@ -254,7 +254,7 @@ function updateStatus(accessory, device) {
 
 function TccAccessory(that, device, sensors) {
   this.log = that.log;
-  //this.log("Adding TCC Device", device.Name);
+  this.log("Adding TCC Device", device.Name);
   this.name = device.Name;
   this.ThermostatID = device.ThermostatID;
   this.device = device;
@@ -409,7 +409,7 @@ function TccAccessory(that, device, sensors) {
 
 function TccSensorsAccessory(that, device, sensors) {
   this.log = that.log;
-  //this.log("Adding TCC Sensors Device");
+  this.log("Adding TCC Sensors Device");
   this.name = "Outside Sensors"
   this.ThermostatID = device.ThermostatID;
   this.device = device;

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ tccPlatform.prototype.configureAccessory = function(accessory) {
 
 function pollDevices() {
   thermostats.pollThermostat().then((devices) => {
-    this.log("pollDevices():", this.devices);
+    //this.log("pollDevices():", this.devices); // this works
     myAccessories.forEach(function(accessory) {
       debug("pollDevices - updateStatus", accessory.displayName);
       if (devices.hb[accessory.context.ThermostatID]) {
@@ -142,7 +142,7 @@ function updateStatus(accessory, device) {
 
   // need to get config for this thermostat id
   
-  debug(this.config['devices']);
+  this.log("updateStatus()",this.devices);
   for (var deviceConfig in this.config['devices']) {
     if (deviceConfig.deviceID == device.ThermostatID) {
       this.deviceConfig = deviceConfig;
@@ -209,8 +209,8 @@ function TccAccessory(that, device) {
   this.usePermanentHolds = that.usePermanentHolds;
   this.storage = that.storage;
   this.refresh = that.refresh;
-  this.devices = that.config['devices'];
-  this.log("config" + that.config);
+  this.devices = that.devices;
+  this.log("TccAccessory()" + this.devices);
   
   var uuid = UUIDGen.generate(this.name + " - TCC");
 

--- a/index.js
+++ b/index.js
@@ -242,7 +242,7 @@ function TccAccessory(that, device, config) {
     
     // check if user wants separate temperature and humidity sensors by zone/thermostat
     if (thisDeviceConfig.insideTemperature || false) {
-      debug("TccAccessory() " + this.Name + " InsideTemperature = true");
+      debug("TccAccessory() " + this.name + " InsideTemperature = true");
       this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "INSIDE");
       
       this.InsideTemperatureService
@@ -253,7 +253,7 @@ function TccAccessory(that, device, config) {
         });
     }
     if (thisDeviceConfig.outsideTemperature || false) {
-      debug("TccAccessory() " + this.Name + " outsideTemperature = true");
+      debug("TccAccessory() " + this.name + " outsideTemperature = true");
       this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "OUTSIDE");
       
       this.OutsideTemperatureService
@@ -264,14 +264,14 @@ function TccAccessory(that, device, config) {
         });
     }
     if (thisDeviceConfig.insideHumidity || false) {
-      debug("TccAccessory() " + this.Name + " insideHumidity = true");
+      debug("TccAccessory() " + this.name + " insideHumidity = true");
       this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "INSIDE");
       
       this.InsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);
     }
     if (thisDeviceConfig.outsideHumidity || false) {
-      debug("TccAccessory() " + this.Name + " outsideHumidity = true");
+      debug("TccAccessory() " + this.name + " outsideHumidity = true");
       this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "OUTSIDE");
       
       this.OutsideHumidityService
@@ -349,7 +349,7 @@ function TccAccessory(that, device, config) {
     // need to check if accessory already exists, but user added temp/humidity sensors then must declare
     this.accessory = getAccessoryByThermostatID(this.ThermostatID);
     if ((thisDeviceConfig.insideTemperature || false)  && !this.accessory.getService(this.Name + " Temperature")) {
-      debug("TccAccessory() " + this.Name + " OutsideTemperature = true, adding sensor");
+      debug("TccAccessory() " + this.name + " OutsideTemperature = true, adding sensor");
       this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "INSIDE");
       
       this.InsideTemperatureService
@@ -360,7 +360,7 @@ function TccAccessory(that, device, config) {
         });
     }
     if ((thisDeviceConfig.outsideTemperature || false)  && !this.accessory.getService("Outside Temperature")) {
-      debug("TccAccessory() " + this.Name + " OutsideTemperature = true, adding sensor");
+      debug("TccAccessory() " + this.name + " OutsideTemperature = true, adding sensor");
       this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "OUTSIDE");
       
       this.OutsideTemperatureService
@@ -371,14 +371,14 @@ function TccAccessory(that, device, config) {
         });
     }
     if ((thisDeviceConfig.insideHumidity || false)  && !this.accessory.getService(this.Name + " Humidity")) {
-      debug("TccAccessory() " + this.Name + " InsideHumidity = true, adding sensor");
+      debug("TccAccessory() " + this.name + " InsideHumidity = true, adding sensor");
       this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "INSIDE");
       
       this.InsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);
     }
     if ((thisDeviceConfig.outsideHumidity || false) && !this.accessory.getService("Outside Humidity")) {
-      debug("TccAccessory() " + this.Name + " outsideHumidity = true, adding sensor");
+      debug("TccAccessory() " + this.name + " outsideHumidity = true, adding sensor");
       this.OutsideHumidityService = this.accessory.addService(Service.HumiditySensor, "Outside Humidity", "OUTSIDE");
       
       this.OutsideHumidityService

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ tccPlatform.prototype.configureAccessory = function(accessory) {
   }
 
   myAccessories.push(accessory);
-  debug(accessory)
+  debug(accessory.context)
 };
 
 function pollDevices() {

--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ function TccAccessory(that, device, config) {
   }
 
   if (!getAccessoryByThermostatID(this.ThermostatID)) {
-    this.log("Adding TCC Device", this.name);
+    this.log("Adding TCC Device (deviceID="+this.ThermostatID+")", this.name);
     this.accessory = new Accessory(this.name, uuid, 10);
     this.accessory.log = that.log;
     this.accessory.context.ThermostatID = device.ThermostatID;
@@ -335,7 +335,7 @@ function TccAccessory(that, device, config) {
     myAccessories.push(this.accessory);
     return this.accessory;
   } else {
-    this.log("Existing TCC accessory", this.name);
+    this.log("Existing TCC accessory (deviceID="+this.ThermostatID+")", this.name);
     
     // need to check if accessory/zone/thermostat already exists, but user added temp/humidity sensors then must declare
     this.accessory = getAccessoryByThermostatID(this.ThermostatID);


### PR DESCRIPTION
Add separate humidity and temperature sensors from thermostats for both inside and outside (see https://github.com/NorthernMan54/homebridge-tcc/issues/76). Because outside values are repeated for each thermostat, needed to add config options for each thermostatID to allow users to only show sensors they are interested in. This took some time to get the code right and I was fighting a lot of the config conditional code and where to put it.

One issue I worked around was in `TccAccessory()` if the devices already exist in the Homebridge instance, we still needed to check for any changes in the config code to add sensors to reflect changes. I have not tested what it means if a user changes config for a sensor from true to false. Probably need a way to detect this and delete the cached accessory/service.

Otherwise, this works great!