### PR TITLE
Fix bug where themostat in "auto" would show "off"

### DIFF
--- a/lib/tccMessage.js
+++ b/lib/tccMessage.js
@@ -242,7 +242,8 @@ function stateValidValues(thermostat) {
 }
 
 function targetState(thermostat) {
-  // TCC to HomeKit  var state;
+  // TCC to HomeKit
+  var state;
   switch (thermostat.UI.SystemSwitchPosition) {
     case 2: // Off
       state = 0;

--- a/lib/tccMessage.js
+++ b/lib/tccMessage.js
@@ -211,13 +211,13 @@ function toThermostat(value, thermostat) {
 function currentState(thermostat) {
   var state = 0;
   switch (thermostat.EquipmentStatus) {
-    case "Off": // Off
+    case "Off":
       state = 0;
       break;
-    case "Heating": // Off
+    case "Heating":
       state = 1;
       break;
-    case "Cooling": // Off
+    case "Cooling":
       state = 2;
       break;
   }
@@ -242,20 +242,20 @@ function stateValidValues(thermostat) {
 }
 
 function targetState(thermostat) {
-  // TCC to HomeKit
-  var state;
+  // TCC to HomeKit  var state;
   switch (thermostat.UI.SystemSwitchPosition) {
     case 2: // Off
-    case 5: // Off on Auto thermostats
       state = 0;
       break;
+    case 0: // Emergency heat
     case 1: // Heat
       state = 1;
       break;
     case 3: // Cool
       state = 2;
       break;
-    case 4: // Auto
+    case 4: // Auto heat
+    case 5: // Auto cool
       state = 3;
       break;
     default:
@@ -273,14 +273,12 @@ function targetTemperature(thermostat) {
       targetTemperature = thermostat.UI.HeatSetpoint;
       break;
     case 1: // Heat
+    case 4: // Auto heat
       targetTemperature = thermostat.UI.HeatSetpoint;
       break;
     case 3: // Cool
+    case 5: // Auto cool
       targetTemperature = thermostat.UI.CoolSetpoint;
-      break;
-    case 4: // Auto
-      // Not sure what to do here, so will use heat set point
-      targetTemperature = thermostat.UI.HeatSetpoint;
       break;
     default:
       // Not sure what to do here, so will display current temperature
@@ -332,7 +330,8 @@ function heatSetpoint(desiredState, thermostat) {
         break;
       case 3: // TCC Cool
         break;
-      case 4: // TCC Auto
+      case 4: // TCC Auto heat
+      case 5: // TCC Auto cool
         response = toThermostat(desiredState.HeatingThresholdTemperature, thermostat);
         break;
     }
@@ -358,7 +357,8 @@ function coolSetpoint(desiredState, thermostat) {
           response = toThermostat(desiredState.CoolingThresholdTemperature, thermostat);
         }
         break;
-      case 4: // TCC Auto
+      case 4: // TCC Auto heat
+      case 5: // TCC Auto cool
         response = toThermostat(desiredState.CoolingThresholdTemperature, thermostat);
         break;
     }


### PR DESCRIPTION
`SystemSwitchPosition` has a valid value of `5`, i.e. "auto mode (cooling)." This value was incorrectly interpreted as "off". It should be interpreted as "auto".

Because my research indicates that a value of `4` is "auto mode (heating)", I was able to modify some code to show the correct target temperatures.

This change fixes issue NorthernMan54#70, which itself is a regression of NorthernMan54#28.