### PR TITLE
Add retries for update thermostat calls

### DIFF
--- a/beta.sh
+++ b/beta.sh
@@ -4,7 +4,7 @@ if npm audit; then
   npm run-script document
   rm *orig* *toc\.*
   git add .
-  npm version patch -m "$1" --force
+  npm version prerelease --preid beta -m "$1" --force
   npm publish --tag beta
   git commit -m "$1"
   git push origin beta --tags

--- a/beta.sh
+++ b/beta.sh
@@ -7,7 +7,7 @@ if npm audit; then
   npm version patch -m "$1" --force
   npm publish --tag beta
   git commit -m "$1"
-  git push origin multiThermo --tags
+  git push origin beta --tags
 else
   echo "Not publishing due to security vulnerabilites"
 fi

--- a/lib/tcc.js
+++ b/lib/tcc.js
@@ -55,7 +55,7 @@ tcc.prototype.pollThermostat = function() {
         this.sessionID = await this._login();
         debug("TCC - Login Succeeded");
       }
-      var current = await retry(this._GetLocationListData.bind(this), 3);
+      var current = await this._GetLocationListData();
       if (this.thermostats.LocationInfo && current.LocationInfo) {
         debug("pollThermostat - delta", JSON.stringify(tccMessage.diff(this.thermostats, current), null, 2));
       }
@@ -80,7 +80,7 @@ tcc.prototype.ChangeThermostat = function(desiredState) {
         debug("TCC - Login Succeeded");
         this.thermostats = await this._GetLocationListData();
       }
-      var CommTaskID = await retry(this._UpdateThermostat.bind(this, desiredState), 3);
+      var CommTaskID = await this._UpdateThermostat(desiredState, true);
       await this._GetCommTaskState(CommTaskID);
       var thermostat = await this._GetThermostat(desiredState.ThermostatID);
       return (thermostat);
@@ -94,28 +94,7 @@ tcc.prototype.ChangeThermostat = function(desiredState) {
 
 // private interface to update thermostat settings
 
-// retry helper
-const retry = async (fn, maxAttempts) => {
-  const execute = async (attempt) => {
-    try {
-      return await fn();
-    } catch (err) {
-      if (attempt <= maxAttempts) {
-        const nextAttempt = attempt + 1;
-        const delayInSeconds = 2*attempt;
-        console.error(`Retrying after ${delayInSeconds} seconds due to:`, err);
-        return delay(() => execute(nextAttempt), delayInSeconds * 1000);
-      } else {
-        throw err;
-      }
-    }
-  }
-  return execute(1);
-}
-
-const delay = (fn, ms) => new Promise((resolve) => setTimeout(() => resolve(fn()), ms));
-
-tcc.prototype._UpdateThermostat = function(desiredState) {
+tcc.prototype._UpdateThermostat = function(desiredState, withRetry) {
   debug("_UpdateThermostat()", desiredState);
   return new Promise((resolve, reject) => {
     (async () => {
@@ -152,11 +131,21 @@ tcc.prototype._UpdateThermostat = function(desiredState) {
           } else {
             this.sessionID = null;
             debug("ERROR: _UpdateThermostat %s", ChangeThermostat.Result, message);
-            reject(new Error("ERROR: _UpdateThermostat", ChangeThermostat.Result));
+            if (withRetry) {
+	      try {
+                const CommTaskID = await this._UpdateThermostat(desiredState, false);
+		resolve(CommTaskID);
+	      } catch (err) {
+		debug("ERROR: _UpdateThermostat retry");
+		reject(err);
+	      }
+	    } else {
+              reject(new Error("ERROR: _UpdateThermostat (200)", ChangeThermostat.Result));
+	    }
           }
         } else {
           debug("ERROR: _UpdateThermostat %s", response, message);
-          reject(new Error("ERROR: _UpdateThermostat", ChangeThermostat.Result));
+          reject(new Error("ERROR: _UpdateThermostat (!200)", ChangeThermostat.Result));
         }
       } catch (err) {
         // console.error("_UpdateThermostat Error:", err);

--- a/lib/tcc.js
+++ b/lib/tcc.js
@@ -55,7 +55,7 @@ tcc.prototype.pollThermostat = function() {
         this.sessionID = await this._login();
         debug("TCC - Login Succeeded");
       }
-      var current = await this._GetLocationListData();
+      var current = await retry(this._GetLocationListData.bind(this), 3);
       if (this.thermostats.LocationInfo && current.LocationInfo) {
         debug("pollThermostat - delta", JSON.stringify(tccMessage.diff(this.thermostats, current), null, 2));
       }
@@ -80,7 +80,7 @@ tcc.prototype.ChangeThermostat = function(desiredState) {
         debug("TCC - Login Succeeded");
         this.thermostats = await this._GetLocationListData();
       }
-      var CommTaskID = await this._UpdateThermostat(desiredState);
+      var CommTaskID = await retry(this._UpdateThermostat.bind(this, desiredState), 3);
       await this._GetCommTaskState(CommTaskID);
       var thermostat = await this._GetThermostat(desiredState.ThermostatID);
       return (thermostat);
@@ -93,6 +93,27 @@ tcc.prototype.ChangeThermostat = function(desiredState) {
 };
 
 // private interface to update thermostat settings
+
+// retry helper
+const retry = async (fn, maxAttempts) => {
+  const execute = async (attempt) => {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt <= maxAttempts) {
+        const nextAttempt = attempt + 1;
+        const delayInSeconds = 2*attempt;
+        console.error(`Retrying after ${delayInSeconds} seconds due to:`, err);
+        return delay(() => execute(nextAttempt), delayInSeconds * 1000);
+      } else {
+        throw err;
+      }
+    }
+  }
+  return execute(1);
+}
+
+const delay = (fn, ms) => new Promise((resolve) => setTimeout(() => resolve(fn()), ms));
 
 tcc.prototype._UpdateThermostat = function(desiredState) {
   debug("_UpdateThermostat()", desiredState);
@@ -131,11 +152,11 @@ tcc.prototype._UpdateThermostat = function(desiredState) {
           } else {
             this.sessionID = null;
             debug("ERROR: _UpdateThermostat %s", ChangeThermostat.Result, message);
-            reject(new Error("ERROR: _UpdateThermostat %s", ChangeThermostat.Result));
+            reject(new Error("ERROR: _UpdateThermostat", ChangeThermostat.Result));
           }
         } else {
           debug("ERROR: _UpdateThermostat %s", response, message);
-          reject(new Error("ERROR: _UpdateThermostat %s", ChangeThermostat.Result));
+          reject(new Error("ERROR: _UpdateThermostat", ChangeThermostat.Result));
         }
       } catch (err) {
         // console.error("_UpdateThermostat Error:", err);

--- a/lib/tcc.js
+++ b/lib/tcc.js
@@ -132,16 +132,16 @@ tcc.prototype._UpdateThermostat = function(desiredState, withRetry) {
             this.sessionID = null;
             debug("ERROR: _UpdateThermostat %s", ChangeThermostat.Result, message);
             if (withRetry) {
-	      try {
+              try {
                 const CommTaskID = await this._UpdateThermostat(desiredState, false);
-		resolve(CommTaskID);
-	      } catch (err) {
-		debug("ERROR: _UpdateThermostat retry");
-		reject(err);
-	      }
-	    } else {
+                resolve(CommTaskID);
+              } catch (err) {
+                debug("ERROR: _UpdateThermostat retry");
+                reject(err);
+              }
+            } else {
               reject(new Error("ERROR: _UpdateThermostat (200)", ChangeThermostat.Result));
-	    }
+            }
           }
         } else {
           debug("ERROR: _UpdateThermostat %s", response, message);
@@ -164,7 +164,9 @@ tcc.prototype._login = function() {
     (async () => {
       try {
         HEADER.soapAction = 'http://services.alarmnet.com/Services/MobileV2/AuthenticateUserLogin';
-        var message = '<?xml version="1.0" encoding="utf-8"?>' + parser.toXml(tccMessage.soapMessage(tccMessage.AuthenticateUserLoginMessage(this._username, this._password)), { sanitize: true });
+        var message = '<?xml version="1.0" encoding="utf-8"?>' + parser.toXml(tccMessage.soapMessage(tccMessage.AuthenticateUserLoginMessage(this._username, this._password)), {
+          sanitize: true
+        });
         var {
           response
         } = await soapRequest({
@@ -344,16 +346,16 @@ tcc.prototype._GetLocationListData = function(withRetry) {
             this.sessionID = null;
             if (withRetry) {
               try {
-		const locListData = await this._GetLocationListData(false);
-		resolve(locListData);
-	      } catch (err) {
-		debug("error get locations retry", err);
-	        reject(err);
-	      }
-	    } else {
+                const locListData = await this._GetLocationListData(false);
+                resolve(locListData);
+              } catch (err) {
+                debug("error get locations retry", err);
+                reject(err);
+              }
+            } else {
               debug("GetLocations error, Info:  %s", GetLocationsResult.Result);
               reject(new Error("GetLocations " + GetLocationsResult.Result));
-	    }
+            }
           }
         } else {
           debug("GetLocations error, statusCode: %s", response.statusCode);

--- a/lib/tcc.js
+++ b/lib/tcc.js
@@ -55,7 +55,7 @@ tcc.prototype.pollThermostat = function() {
         this.sessionID = await this._login();
         debug("TCC - Login Succeeded");
       }
-      var current = await this._GetLocationListData();
+      var current = await this._GetLocationListData(true);
       if (this.thermostats.LocationInfo && current.LocationInfo) {
         debug("pollThermostat - delta", JSON.stringify(tccMessage.diff(this.thermostats, current), null, 2));
       }
@@ -78,7 +78,7 @@ tcc.prototype.ChangeThermostat = function(desiredState) {
       if (!this.sessionID) {
         this.sessionID = await this._login();
         debug("TCC - Login Succeeded");
-        this.thermostats = await this._GetLocationListData();
+        this.thermostats = await this._GetLocationListData(true);
       }
       var CommTaskID = await this._UpdateThermostat(desiredState, true);
       await this._GetCommTaskState(CommTaskID);
@@ -305,10 +305,13 @@ tcc.prototype._GetThermostat = function(ThermostatID) {
 
 // private interface to retrieve all thermostat settings
 
-tcc.prototype._GetLocationListData = function() {
+tcc.prototype._GetLocationListData = function(withRetry) {
   return new Promise((resolve, reject) => {
     (async () => {
       try {
+        if (!this.sessionID) {
+          this.sessionID = await this._login();
+        }
         HEADER.soapAction = 'http://services.alarmnet.com/Services/MobileV2/GetLocations';
         var message = '<?xml version="1.0" encoding="utf-8"?>' + parser.toXml(tccMessage.soapMessage(tccMessage.GetLocationsMessage(this.sessionID)));
         // debug("SOAP Message", parser.toXml(soapMessage(GetLocations)));
@@ -339,14 +342,25 @@ tcc.prototype._GetLocationListData = function() {
             resolve(tccMessage.normalizeToHb(GetLocationsResult.Locations));
           } else {
             this.sessionID = null;
-            // debug("Info:  %s", GetLocationsResult.Result, message);
-            reject(new Error("GetLocations " + GetLocationsResult.Result));
+            if (withRetry) {
+              try {
+		const locListData = await this._GetLocationListData(false);
+		resolve(locListData);
+	      } catch (err) {
+		debug("error get locations retry", err);
+	        reject(err);
+	      }
+	    } else {
+              debug("GetLocations error, Info:  %s", GetLocationsResult.Result);
+              reject(new Error("GetLocations " + GetLocationsResult.Result));
+	    }
           }
         } else {
+          debug("GetLocations error, statusCode: %s", response.statusCode);
           reject(new Error("ERROR: GetLocations Response Status Code", response.statusCode));
         }
       } catch (err) {
-        // console.error("GetLocations Error:", err.message);
+        console.error("GetLocations Error:", err);
         this.sessionID = null;
         reject(err);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-tcc",
-  "version": "0.2.26",
+  "version": "0.2.27-beta.0",
   "description": "Honeywell Total Connect Comfort support for Homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-tcc",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "description": "Honeywell Total Connect Comfort support for Homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [


### PR DESCRIPTION
Tks to @atlcoder for this work and PR #110 

I've been using this plugin with homebridge, and it seems to work most of the time. Once in a while, when the thermostat is updated, I get errors like this in the logs:

Sun, 30 Jan 2022 21:36:50 GMT tcc-lib ERROR: _UpdateThermostat InvalidSessionID <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://services.alarmnet.com/Services/MobileV2/"><soap:Body><ChangeThermostatUI><sessionID>REDACTED</sessionID><thermostatID>REDACTED</thermostatID><changeSystemSwitch>1</changeSystemSwitch><systemSwitch>1</systemSwitch><changeHeatSetpoint>1</changeHeatSetpoint><heatSetpoint>60</heatSetpoint><changeCoolSetpoint>1</changeCoolSetpoint><coolSetpoint>74</coolSetpoint><changeHeatNextPeriod>1</changeHeatNextPeriod><heatNextPeriod>72</heatNextPeriod><changeCoolNextPeriod>1</changeCoolNextPeriod><coolNextPeriod>72</coolNextPeriod><changeStatusHeat>1</changeStatusHeat><statusHeat>2</statusHeat><changeStatusCool>1</changeStatusCool><statusCool>2</statusCool></ChangeThermostatUI></soap:Body></soap:Envelope>
ChangeThermostat Error: Error: ERROR: _UpdateThermostat %s
    at /opt/homebrew/lib/node_modules/homebridge-tcc/lib/tcc.js:134:20
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
It looks like when this happens, the session ID is then cleared, and if the session ID is empty, a new login will be performed on the next api call. So, since the code should already self-heal, I'm attempting to add retries.

Potential resolution for https://github.com/NorthernMan54/homebridge-tcc/issues/109