### PR TITLE
Sensor Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ To resolve the issue, please follow the steps here. https://github.com/nodejs/no
   * `none` - No sensors will be shown (this is default setting)
   * `all` - Enables all available temperature/humidity sensors
   * `inside` - Enables temperature and humidity sensors for each thermostat
+  * `insideHumidity` - Enables inside humidity sensors for each thermostat
   * `outside` - Enables a single set of outdoor temperature and humidity sensors
 * `debug` - Enables debug level logging from the plugin, defaults to `false`, to enable set to `true`
 

--- a/index.js
+++ b/index.js
@@ -254,20 +254,29 @@ function TccAccessory(that, device, sensors) {
 
   var uuid = UUIDGen.generate(this.name + " - TCC");
   var createInsideSensors = false;
+  var createInsideTemperatureSensors = false;
 
   // need to get config for this thermostat id
   switch (sensors) {
     case "none":
       createInsideSensors = false;
+      createInsideTemperatureSensors = false;
       break;
     case "all":
       createInsideSensors = true;
+      createInsideTemperatureSensors = true;
       break;
     case "inside":
       createInsideSensors = true;
+      createInsideTemperatureSensors = true;
+      break;
+    case "insideHumidity":
+      createInsideSensors = true;
+      createInsideTemperatureSensors = false;
       break;
     case "outside":
       createInsideSensors = false;
+      createInsideTemperatureSensors = false;
       break;
   }
 
@@ -289,15 +298,18 @@ function TccAccessory(that, device, sensors) {
 
     // check if user wants separate temperature and humidity sensors by zone/thermostat
     debug("createInsideSensors: ", createInsideSensors);
+    debug("createInsideTemperatureSensors: ", createInsideTemperatureSensors);
     if (createInsideSensors) {
-      // debug("TccAccessory() " + this.name + " InsideTemperature = true, existing sensor");
-      this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "Inside");
-      this.InsideTemperatureService
-        .getCharacteristic(Characteristic.CurrentTemperature)
-        .setProps({
-          minValue: -100, // If you need this, you have major problems!!!!!
-          maxValue: 100
-        });
+      if (createInsideTemperatureSensors) {
+        // debug("TccAccessory() " + this.name + " InsideTemperature = true, existing sensor");
+        this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "Inside");
+        this.InsideTemperatureService
+            .getCharacteristic(Characteristic.CurrentTemperature)
+            .setProps({
+              minValue: -100, // If you need this, you have major problems!!!!!
+              maxValue: 100
+            });
+      }
 
       debug("TccAccessory() " + this.name + " insideHumidity = true, existing sensor");
       this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "Inside");
@@ -376,7 +388,7 @@ function TccAccessory(that, device, sensors) {
     this.accessory = getAccessoryByName(this.name);
     debug("Heating Threshold", this.accessory.getService(Service.Thermostat).getCharacteristic(Characteristic.HeatingThresholdTemperature).props);
     debug("Cooling Threshold", this.accessory.getService(Service.Thermostat).getCharacteristic(Characteristic.CoolingThresholdTemperature).props);
-    if (createInsideSensors && !this.accessory.getService(this.name + " Temperature")) {
+    if (createInsideSensors && createInsideTemperatureSensors && !this.accessory.getService(this.name + " Temperature")) {
       debug("TccAccessory() " + this.name + " InsideTemperature = true, adding sensor");
       this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "Inside");
 
@@ -386,7 +398,7 @@ function TccAccessory(that, device, sensors) {
           minValue: -100, // If you need this, you have major problems!!!!!
           maxValue: 100
         });
-    } else if (!createInsideSensors && this.accessory.getService(this.name + " Temperature")) {
+    } else if ((!createInsideSensors || !createInsideTemperatureSensors) && this.accessory.getService(this.name + " Temperature")) {
       this.accessory.removeService(this.accessory.getService(this.name + " Temperature"));
     }
     if (createInsideSensors && !this.accessory.getService(this.name + " Humidity")) {

--- a/index.js
+++ b/index.js
@@ -386,6 +386,8 @@ function TccAccessory(that, device, sensors) {
           minValue: -100, // If you need this, you have major problems!!!!!
           maxValue: 100
         });
+    } else if (!createInsideSensors && this.accessory.getService(this.name + " Temperature")) {
+      this.accessory.removeService(this.accessory.getService(this.name + " Temperature"));
     }
     if (createInsideSensors && !this.accessory.getService(this.name + " Humidity")) {
       debug("TccAccessory() " + this.name + " InsideHumidity = true, adding sensor");
@@ -393,6 +395,8 @@ function TccAccessory(that, device, sensors) {
 
       this.InsideHumidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity);
+    } else if (!createInsideSensors && this.accessory.getService(this.name + " Humidity")) {
+      this.accessory.removeService(this.accessory.getService(this.name + " Humidity"));
     }
     return this.accessory;
   }

--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ tccPlatform.prototype.didFinishLaunching = function() {
 
       // does user want outside sensors created? if so, only create 1 set
       if ((this.sensors == "all" || this.sensors == "outside") && outsideSensors == 0) {
+        // Check for invalid humidity value
         if (devices.hb[zone].OutsideHumidity == 128) {
           debug("Invalid outside humidity value for", devices.hb[zone].Name + "(" + devices.hb[zone].ThermostatID + ")");
         } else {
@@ -284,7 +285,7 @@ function TccAccessory(that, device, sensors) {
       break;
   }
 
-  // Check for invalid humidity values
+  // Check for invalid humidity value
   if (device.InsideHumidity == 128) {
     debug("Invalid inside humidity value for", device.Name + "(" + device.ThermostatID + ")");
     createInsideHumiditySensors = false;
@@ -309,24 +310,22 @@ function TccAccessory(that, device, sensors) {
     // check if user wants separate temperature and humidity sensors by zone/thermostat
     debug("createInsideHumiditySensors: ", createInsideHumiditySensors);
     debug("createInsideTemperatureSensors: ", createInsideTemperatureSensors);
-    if (createInsideHumiditySensors || createInsideTemperatureSensors) {
-      if (createInsideTemperatureSensors) {
-        // debug("TccAccessory() " + this.name + " InsideTemperature = true, existing sensor");
-        this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "Inside");
-        this.InsideTemperatureService
-            .getCharacteristic(Characteristic.CurrentTemperature)
-            .setProps({
-              minValue: -100, // If you need this, you have major problems!!!!!
-              maxValue: 100
-            });
-      }
+    if (createInsideTemperatureSensors) {
+      // debug("TccAccessory() " + this.name + " InsideTemperature = true, existing sensor");
+      this.InsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, this.name + " Temperature", "Inside");
+      this.InsideTemperatureService
+          .getCharacteristic(Characteristic.CurrentTemperature)
+          .setProps({
+            minValue: -100, // If you need this, you have major problems!!!!!
+            maxValue: 100
+          });
+    }
 
-      if (createInsideHumiditySensors) {
-        debug("TccAccessory() " + this.name + " insideHumidity = true, existing sensor");
-        this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "Inside");
-        this.InsideHumidityService
-            .getCharacteristic(Characteristic.CurrentRelativeHumidity);
-      }
+    if (createInsideHumiditySensors) {
+      debug("TccAccessory() " + this.name + " insideHumidity = true, existing sensor");
+      this.InsideHumidityService = this.accessory.addService(Service.HumiditySensor, this.name + " Humidity", "Inside");
+      this.InsideHumidityService
+          .getCharacteristic(Characteristic.CurrentRelativeHumidity);
     }
 
     //       .setProps({validValues: hbValues.TargetHeatingCoolingStateValidValues})


### PR DESCRIPTION
- If temperature/humidity sensors were previously enabled and later disabled, those sensors are now removed from homebridge
- Added new `sensors` option `insideHumidity` to add only inside humidity sensors, since HomeKit shows the current thermostat value in its climate status
- Added detection for an invalid humidity value of `128`, which appears when that humidity sensor is not installed. Partially fixing #96 

I did not fix the other part of #96 (invalid outdoor temperature) because the value of `53.3` could possibly be accurate.