### PR TITLE
Fixed version of "Remove outdoor sensors when user changes setting"

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -2,7 +2,7 @@
   "pluginAlias": "tcc",
   "pluginType": "platform",
   "singular": true,
-  "headerDisplay": "<p align='center'><img width='250px' src='https://user-images.githubusercontent.com/3979615/71876008-d99d7400-3179-11ea-909b-9d2a3d1e670f.png'></p>\n\nThe **Homebridge TCC** plugin allows you to control your North American Honeywell Total Comformt Connect thermostats from HomeKit. ",
+  "headerDisplay": "<p align='center'><img width='250px' src='https://user-images.githubusercontent.com/3979615/71876008-d99d7400-3179-11ea-909b-9d2a3d1e670f.png'></p>\n\nThe **Homebridge TCC** plugin allows you to control your North American Honeywell Total Comformt Connect thermostats from HomeKit.",
   "footerDisplay": "",
   "schema": {
     "type": "object",
@@ -26,6 +26,41 @@
         "required": true,
         "description": "Your Honeywell password."
       },
+      "usePermanentHolds": {
+        "title": "Use Permanent Holds",
+        "type": "boolean",
+        "required": false,
+        "description": "If set to true, temperature changes will be set as permanent holds, rather than temporary holds. This will allow you to use HomeKit automations to completely replace your thermostat's schedule. If set to false, the temperature changes will expire after a certain period of time and resume your normal schedule. By default, this is off."
+      },
+      "sensors": {
+        "title": "Sensors",
+        "type": "string",
+        "description": "Create temperature and humidity HomeKit sensors that are useful for automations, defaults to none.",
+        "default": "none",
+        "required": true,
+        "oneOf": [
+          {
+            "title": "None (default)",
+            "enum": ["none"]
+          },
+          {
+            "title": "Indoor temperature and humidity",
+            "enum": ["inside"]
+          },
+          {
+            "title": "Indoor humidity",
+            "enum": ["insideHumidity"]
+          },
+          {
+            "title": "Outdoor temperature and humidity",
+            "enum": ["outside"]
+          },
+          {
+            "title": "All available",
+            "enum": ["all"]
+          }
+        ]
+      },
       "refresh": {
         "title": "Refresh Token",
         "default": 600,
@@ -37,11 +72,12 @@
       "storage": {
         "title": "Storage",
         "type": "string",
-        "required": false,
+        "required": true,
         "description": "Storage of chart graphing data for history graphing, either fs or googleDrive, defaults to fs.",
         "default": "fs",
-        "oneOf": [{
-            "title": "File System",
+        "oneOf": [
+          {
+            "title": "File System (default)",
             "enum": ["fs"]
           },
           {
@@ -49,12 +85,6 @@
             "enum": ["googleDrive"]
           }
         ]
-      },
-      "usePermanentHolds": {
-        "title": "usePermanentHolds",
-        "type": "boolean",
-        "required": false,
-        "description": "If set to true, temperature changes will be set as permanent holds, rather than temporary holds. This will allow you to use HomeKit automations to completely replace your thermostat's schedule. If set to false, the temperature changes will expire after a certain period of time and resume your normal schedule. By default, this is off."
       },
       "debug": {
         "title": "Debug Logging",
@@ -64,25 +94,18 @@
       }
     }
   },
-  "layout": [{
+  "layout": [
+    {
       "type": "fieldset",
       "title": "Thermostat",
-      "items": [
-        "username",
-        "password"
-      ]
+      "items": ["username", "password", "sensors", "usePermanentHolds"]
     },
     {
       "type": "fieldset",
       "title": "Optional Settings",
       "expandable": true,
       "expanded": false,
-      "items": [
-        "refresh",
-        "storage",
-        "usePermanentHolds",
-        "debug"
-      ]
+      "items": ["refresh", "storage", "debug"]
     }
   ]
 }

--- a/index.js
+++ b/index.js
@@ -54,8 +54,8 @@ tccPlatform.prototype.didFinishLaunching = function() {
     for (var zone in devices.hb) {
       debug("Creating accessory for", devices.hb[zone].Name + "(" + devices.hb[zone].ThermostatID + ")");
       //debug("tccPlatform.prototype.didFinishLaunching()",this.devices)
-      var newAccessory = new TccAccessory(this, devices.hb[zone], this.sensors);
-      updateStatus(newAccessory, devices.hb[zone]);
+      var thermostatAccessory = new TccAccessory(this, devices.hb[zone], this.sensors);
+      updateStatus(thermostatAccessory, devices.hb[zone]);
 
       const createOutsideSensors = (this.sensors == "all" || this.sensors == "outside")
 
@@ -65,21 +65,25 @@ tccPlatform.prototype.didFinishLaunching = function() {
         if (devices.hb[zone].OutsideHumidity == 128) {
           debug("Invalid outside humidity value for", devices.hb[zone].Name + "(" + devices.hb[zone].ThermostatID + ")");
         } else {
-          var newSensorsAccessory = new TccSensorsAccessory(this, devices.hb[zone], this.sensors);
-          updateStatus(newSensorsAccessory, devices.hb[zone]);
+          const outsideAccessory = new TccSensorsAccessory(this, devices.hb[zone], this.sensors);
+          updateStatus(outsideAccessory, devices.hb[zone]);
           outsideSensorsCreated = true;
         }
       } else if (!createOutsideSensors) {
-        const outsideTempSensor = newAccessory.getService("Outside Temperature");
+        const outsideAccessory = getAccessoryByName("Outside Sensors");
 
-        if (outsideTempSensor) {
-          newAccessory.removeService(outsideTempSensor);
-        }
+        if (outsideAccessory) {
+          const outsideTempSensor = outsideAccessory.getService("Outside Temperature");
 
-        const outsideHumiditySensor = newAccessory.getService("Outside Humidity");
+          if (outsideTempSensor) {
+            outsideAccessory.removeService(outsideTempSensor);
+          }
 
-        if (outsideHumiditySensor) {
-          newAccessory.removeService(outsideHumiditySensor);
+          const outsideHumiditySensor = outsideAccessory.getService("Outside Humidity");
+
+          if (outsideHumiditySensor) {
+            outsideAccessory.removeService(outsideHumiditySensor);
+          }
         }
       }
     }
@@ -442,7 +446,7 @@ function TccAccessory(that, device, sensors) {
 function TccSensorsAccessory(that, device, sensors) {
   this.log = that.log;
   //this.log("Adding TCC Sensors Device");
-  this.name = "Outside Sensors"
+  this.name = "Outside Sensors";
   this.ThermostatID = device.ThermostatID;
   this.device = device;
   this.storage = that.storage;
@@ -493,7 +497,7 @@ function TccSensorsAccessory(that, device, sensors) {
     this.log("Existing TCC outside sensors accessory (deviceID=" + this.ThermostatID + ")", this.name);
 
     // need to check if accessory/zone/thermostat already exists, but user added temp/humidity sensors then must declare
-    this.accessory = getAccessoryByName("Outside Sensors");
+    this.accessory = getAccessoryByName(this.name);
     if (!this.accessory.getService("Outside Temperature")) {
       debug("TccSensorsAccessory() " + this.name + " OutsideTemperature = true, adding sensor");
       this.OutsideTemperatureService = this.accessory.addService(Service.TemperatureSensor, "Outside Temperature", "Outside");

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const moment = require('moment');
 
 var myAccessories = [];
 var thermostats;
-var outsideSensors = 0;
+var outsideSensorsCreated = false;
 
 module.exports = function(homebridge) {
   Accessory = homebridge.platformAccessory;
@@ -57,15 +57,29 @@ tccPlatform.prototype.didFinishLaunching = function() {
       var newAccessory = new TccAccessory(this, devices.hb[zone], this.sensors);
       updateStatus(newAccessory, devices.hb[zone]);
 
+      const createOutsideSensors = (this.sensors == "all" || this.sensors == "outside")
+
       // does user want outside sensors created? if so, only create 1 set
-      if ((this.sensors == "all" || this.sensors == "outside") && outsideSensors == 0) {
+      if (createOutsideSensors && !outsideSensorsCreated) {
         // Check for invalid humidity value
         if (devices.hb[zone].OutsideHumidity == 128) {
           debug("Invalid outside humidity value for", devices.hb[zone].Name + "(" + devices.hb[zone].ThermostatID + ")");
         } else {
           var newSensorsAccessory = new TccSensorsAccessory(this, devices.hb[zone], this.sensors);
           updateStatus(newSensorsAccessory, devices.hb[zone]);
-          outsideSensors = 1;
+          outsideSensorsCreated = true;
+        }
+      } else if (!createOutsideSensors) {
+        const outsideTempSensor = newAccessory.getService("Outside Temperature");
+
+        if (outsideTempSensor) {
+          newAccessory.removeService(outsideTempSensor);
+        }
+
+        const outsideHumiditySensor = newAccessory.getService("Outside Humidity");
+
+        if (outsideHumiditySensor) {
+          newAccessory.removeService(outsideHumiditySensor);
         }
       }
     }


### PR DESCRIPTION
- Fix non-existent object, causing errors in current version, from #126 
- Add config schema

Can be tested by using a `sensors` setting that doesn't include outdoor sensors.

I have not tested with my own install yet but will do so and provide a comment here.

Errors look like:
```
[Thermostat] Critical Error - No devices created, please restart.
[Thermostat] Cannot read properties of undefined (reading 'getService')
```

I've updates the settings schema to show an option for sensors:

<img width="845" alt="Screenshot 2023-03-07 at 5 36 17 PM" src="https://user-images.githubusercontent.com/37423111/223597707-f90ef7df-0621-41b1-b0e3-fd12d747954c.png">

<img width="827" alt="Screenshot 2023-03-07 at 5 36 27 PM" src="https://user-images.githubusercontent.com/37423111/223597714-373473ef-a68a-4c31-9290-d9d4068ac0df.png">
